### PR TITLE
[Feature] #01 인증 기본 뼈대 및 Swagger 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ replay_pid*
 # application.yml은 공유하되, 보안이 필요한 경우 application-local.yml 등을 따로 만들어 관리하세요.
 # .yml (주석 처리: 전체 차단 해제
 application-dev.yml
+.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-batch")
+    //implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    //implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     compileOnly("org.projectlombok:lombok")
@@ -40,6 +40,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+
+    //Swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/backend/mossy/auth/config/PasswordConfig.java
+++ b/src/main/java/backend/mossy/auth/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package backend.mossy.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/backend/mossy/auth/config/SecurityConfig.java
+++ b/src/main/java/backend/mossy/auth/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package backend.mossy.auth.config;
 
 import backend.mossy.auth.security.RestAccessDeniedHandler;
 import backend.mossy.auth.security.RestAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -14,37 +15,38 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+    private final RestAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-
-                //CSRF 비활성
+                // CSRF 비활성
                 .csrf(csrf -> csrf.disable())
-                //CORS 설정
+                // CORS 설정
                 .cors(Customizer.withDefaults())
-                //세션 인증 방식 비활성, JWT 사용 방식으로 변경
+                // 세션 인증 방식 비활성, JWT 사용 방식으로 변경
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                //폼 로그인 비활성
+                // 폼 로그인 비활성
                 .formLogin(form -> form.disable())
-                //기본 인증 비활성
+                // 기본 인증 비활성
+                .httpBasic(basic -> basic.disable())
 
                 // 인증 / 인가 예외 처리
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(new RestAuthenticationEntryPoint())
-                        .accessDeniedHandler(new RestAccessDeniedHandler())
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
 
-                // 접근 권한 설정
+                // 접근 권한 설정 (개발 초기: 전체 허용)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/**").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 );
-
-        // JWT 필터는 다음 PR에서 추가 예정
-        // http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/backend/mossy/auth/config/SecurityConfig.java
+++ b/src/main/java/backend/mossy/auth/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package backend.mossy.auth.config;
+
+import backend.mossy.auth.security.RestAccessDeniedHandler;
+import backend.mossy.auth.security.RestAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+
+                //CSRF 비활성
+                .csrf(csrf -> csrf.disable())
+                //CORS 설정
+                .cors(Customizer.withDefaults())
+                //세션 인증 방식 비활성, JWT 사용 방식으로 변경
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                //폼 로그인 비활성
+                .formLogin(form -> form.disable())
+                //기본 인증 비활성
+
+                // 인증 / 인가 예외 처리
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+                        .accessDeniedHandler(new RestAccessDeniedHandler())
+                )
+
+                // 접근 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        // JWT 필터는 다음 PR에서 추가 예정
+        // http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/backend/mossy/auth/controller/AuthPingController.java
+++ b/src/main/java/backend/mossy/auth/controller/AuthPingController.java
@@ -1,0 +1,15 @@
+package backend.mossy.auth.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthPingController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/main/java/backend/mossy/auth/security/RestAccessDeniedHandler.java
+++ b/src/main/java/backend/mossy/auth/security/RestAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package backend.mossy.auth.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.access.AccessDeniedException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        om.writeValue(response.getWriter(), Map.of(
+                "success", false,
+                "code", "AUTH_403",
+                "message", "접근 권한이 없습니다",
+                "path", request.getRequestURI()
+        ));
+    }
+}

--- a/src/main/java/backend/mossy/auth/security/RestAccessDeniedHandler.java
+++ b/src/main/java/backend/mossy/auth/security/RestAccessDeniedHandler.java
@@ -2,16 +2,20 @@ package backend.mossy.auth.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
 
+@Component
+@RequiredArgsConstructor
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
-    private final ObjectMapper om = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
@@ -20,7 +24,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        om.writeValue(response.getWriter(), Map.of(
+        objectMapper.writeValue(response.getWriter(), Map.of(
                 "success", false,
                 "code", "AUTH_403",
                 "message", "접근 권한이 없습니다",

--- a/src/main/java/backend/mossy/auth/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/backend/mossy/auth/security/RestAuthenticationEntryPoint.java
@@ -3,17 +3,20 @@ package backend.mossy.auth.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
 
+@Component
+@RequiredArgsConstructor
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
-
-    private final ObjectMapper om = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
@@ -23,7 +26,7 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        om.writeValue(response.getWriter(), Map.of(
+        objectMapper.writeValue(response.getWriter(), Map.of(
                 "success", false,
                 "code", "AUTH_401",
                 "message", "인증이 필요합니다.",

--- a/src/main/java/backend/mossy/auth/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/backend/mossy/auth/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package backend.mossy.auth.security;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        om.writeValue(response.getWriter(), Map.of(
+                "success", false,
+                "code", "AUTH_401",
+                "message", "인증이 필요합니다.",
+                "path", request.getRequestURI()
+        ));
+    }
+}

--- a/src/main/java/backend/mossy/boundedContext/member/domain/Member.java
+++ b/src/main/java/backend/mossy/boundedContext/member/domain/Member.java
@@ -1,0 +1,4 @@
+package backend.mossy.boundedContext.member.domain;
+
+public class Member {
+}

--- a/src/main/java/backend/mossy/global/batch/BatchConfig.java
+++ b/src/main/java/backend/mossy/global/batch/BatchConfig.java
@@ -1,19 +1,10 @@
-package backend.mossy.global.batch;
+//package backend.mossy.global.batch;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
-import org.springframework.batch.core.configuration.annotation.EnableJdbcJobRepository;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.datasource.init.DataSourceInitializer;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+//import org.springframework.context.annotation.Configuration;
 
-import javax.sql.DataSource;
+//@Configuration
+//@EnableBatchProcessing
+//@EnableJdbcJobRepository
+//public class BatchConfig {
 
-@Configuration
-@EnableBatchProcessing
-@EnableJdbcJobRepository
-public class BatchConfig {
-
-}
+//}

--- a/src/main/java/backend/mossy/global/config/OpenApiConfig.java
+++ b/src/main/java/backend/mossy/global/config/OpenApiConfig.java
@@ -1,0 +1,4 @@
+package backend.mossy.global.config;
+
+public class OpenApiConfig {
+}

--- a/src/main/java/backend/mossy/global/config/OpenApiConfig.java
+++ b/src/main/java/backend/mossy/global/config/OpenApiConfig.java
@@ -1,4 +1,19 @@
 package backend.mossy.global.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI mossyOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Mossy API Documentation")
+                        .description("Mossy 이커머스 플랫폼 API 문서")
+                        .version("v1.0.0"));
+    }
 }

--- a/src/main/java/backend/mossy/shared/member/domain/BaseMember.java
+++ b/src/main/java/backend/mossy/shared/member/domain/BaseMember.java
@@ -1,6 +1,6 @@
 package backend.mossy.shared.member.domain;
 
-import com.back.global.jpa.entity.BaseEntity;
+import backend.mossy.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,17 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 100
+
+##swagger
+springdoc:
+  swagger-ui:
+    path: /mossy-docs
+
 logging:
   level:
     com.back: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+
+


### PR DESCRIPTION
## 📑 이슈 번호
- close #01

## ✨️ 작업 내용
- Spring Security 기반 인증 기본 설정 구성
- 인증/인가 실패 시 공통 JSON 응답 처리
- Stateless 인증 구조 준비
- Swagger(OpenAPI) 연동 및 문서 경로 설정
- 개발 환경(dev) MySQL 연결 설정

## 💙 코멘트
- JWT 필터는 다음 PR에서 추가 예정입니다.
- 현재는 인증 구조 및 문서화 뼈대 검증에 집중했습니다.

## 📸 구현 결과
- Swagger UI 접속 가능 (/mossy-docs)
- 인증 API 정상 동작 확인
<img width="1437" height="748" alt="image" src="https://github.com/user-attachments/assets/ee51a273-5f5b-48df-bda1-f12ae1315c08" />
