### PR TITLE
[Feature] #06 예치금 서비스 기반 구조 및 도메인 모델 구축

### DIFF
--- a/src/main/java/backend/mossy/boundedContext/cash/domain/history/CashLog.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/history/CashLog.java
@@ -1,0 +1,42 @@
+package backend.mossy.boundedContext.cash.domain.history;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import backend.mossy.boundedContext.cash.domain.wallet.CashMember;
+import backend.mossy.boundedContext.cash.domain.wallet.Wallet;
+import backend.mossy.global.jpa.entity.BaseIdAndTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "CASH_CASH_LOG")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashLog extends BaseIdAndTime {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EventType eventType;
+    @Column(nullable = false)
+    private String relTypeCode;
+    @Column(nullable = false)
+    private int relId;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private CashMember member;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "wallet_id")
+    private Wallet wallet;
+    @Column(nullable = false)
+    private long amount;
+    @Column(nullable = false)
+    private long balance;
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/history/EventType.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/history/EventType.java
@@ -1,0 +1,12 @@
+package backend.mossy.boundedContext.cash.domain.history;
+
+public enum EventType {
+    충전__무통장입금,
+    충전__PG결제_토스페이먼츠,
+    사용__주문결제,
+    임시보관__주문결제,
+    정산지급__상품판매_수수료,
+    정산수령__상품판매_수수료,
+    정산지급__상품판매_대금,
+    정산수령__상품판매_대금,
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PayMethod.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PayMethod.java
@@ -1,0 +1,13 @@
+package backend.mossy.boundedContext.cash.domain.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PayMethod {
+    CARD("신용/체크카드"),
+    CASH("예치금");
+
+    private final String description;
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/payment/Payment.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/payment/Payment.java
@@ -18,10 +18,7 @@ import lombok.NoArgsConstructor;
 public class Payment extends BaseManualIdAndTime {
 
     @Embedded
-    private PaymentReference reference; // 복합키 (orderId + buyerId)
-
-    @Column(unique = true)
-    private String pgUid; // PG사 거래 고유 번호
+    private PaymentReference reference; // 복합키 (orderId + buyerId + pgUid)
 
     @Column(nullable = false)
     private long amount; // 결제 금액

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/payment/Payment.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/payment/Payment.java
@@ -1,0 +1,36 @@
+package backend.mossy.boundedContext.cash.domain.payment;
+
+import backend.mossy.global.jpa.entity.BaseManualIdAndTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "PAYMENT_PAYMENT")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseManualIdAndTime {
+
+    @Embedded
+    private PaymentReference reference; // 복합키 (orderId + buyerId)
+
+    @Column(unique = true)
+    private String pgUid; // PG사 거래 고유 번호
+
+    @Column(nullable = false)
+    private long amount; // 결제 금액
+
+    @Enumerated(EnumType.STRING)
+    private PayMethod payMethod; // 결제 수단
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status; // 결제 상태
+
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PaymentReference.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PaymentReference.java
@@ -18,4 +18,6 @@ public class PaymentReference implements Serializable {
     private Long orderId; // 주문 ID
     @Column(nullable = false)
     private Long buyerId;  // 구매자 ID
+    @Column(unique = true)
+    private String pgUid; // PG사 거래 고유 번호
 }

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PaymentReference.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PaymentReference.java
@@ -1,0 +1,21 @@
+package backend.mossy.boundedContext.cash.domain.payment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class PaymentReference implements Serializable {
+
+    @Column(nullable = false)
+    private Long orderId; // 주문 ID
+    @Column(nullable = false)
+    private Long buyerId;  // 구매자 ID
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PaymentStatus.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/payment/PaymentStatus.java
@@ -1,0 +1,17 @@
+package backend.mossy.boundedContext.cash.domain.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+    READY("결제준비"),
+    PAID("결제완료"),
+    FAILED("결제실패"),
+    CANCELED("전체취소"),
+    PARTIAL_CANCELED("부분취소"),
+    REFUND_IN_PROGRESS("환불진행중");
+
+    private final String description;
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/wallet/CashMember.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/wallet/CashMember.java
@@ -1,0 +1,16 @@
+package backend.mossy.boundedContext.cash.domain.wallet;
+
+import backend.mossy.shared.member.domain.ReplicaMember;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "CASH_MEMBER")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashMember extends ReplicaMember {
+    //수정 필요
+}

--- a/src/main/java/backend/mossy/boundedContext/cash/domain/wallet/Wallet.java
+++ b/src/main/java/backend/mossy/boundedContext/cash/domain/wallet/Wallet.java
@@ -1,0 +1,33 @@
+package backend.mossy.boundedContext.cash.domain.wallet;
+
+import backend.mossy.boundedContext.cash.domain.history.CashLog;
+import backend.mossy.global.jpa.entity.BaseManualIdAndTime;
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.REMOVE;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "CASH_WALLET")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Wallet extends BaseManualIdAndTime {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private CashMember member;
+
+    private long balance = 0;
+
+    @OneToMany(mappedBy = "wallet", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
+    private List<CashLog>  transactions = new ArrayList<>();
+}

--- a/src/main/java/backend/mossy/shared/member/domain/BaseMember.java
+++ b/src/main/java/backend/mossy/shared/member/domain/BaseMember.java
@@ -1,6 +1,6 @@
 package backend.mossy.shared.member.domain;
 
-import com.back.global.jpa.entity.BaseEntity;
+import backend.mossy.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;


### PR DESCRIPTION
## 📑 이슈 번호
- close #6 

## ✨️ 작업 내용
- boundedContext.cash 패키지 생성 (app, domain, in, out)
- CashMember 생성
- Wallet, CashLog 생성
- Payment 생성 (PaymentReference 임베디드 구조 적용)
- Enum 타입 (PaymentStatus, EventType, PayMethod) 생성

## 💙 코멘트
CashMember : 차후 예치금 전용 회원 인증 및 권한 관리 등 세부 기능 구현 시점에 맞춰 구체적인 로직과 필드를 추가로 작성할 예정
PaymentReference : '외부 시스템과의 연결 고리'들을 하나로 묶어서, PG사가 바뀌어도 결제 본연의 로직은 흔들리지 않게 보호하고 돈이 중복으로 나가는 사고를 원천 차단하기 위함

## 📸 구현 결과
<img width="282" height="405" alt="스크린샷 2026-01-14 오전 11 29 50" src="https://github.com/user-attachments/assets/1baaed32-9eb3-46de-8a35-b4e600ce139c" />
