### PR TITLE
[Feature] #91 Redis 기반 Refresh Token 저장 및 재발급 로직 구현

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ services:
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     networks:
       - elastic
+
   kibana:
     image: kibana:9.2.2
     container_name: kibana
@@ -17,11 +18,27 @@ services:
       SERVER_NAME: kibana
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     ports:
-      - 5601:5601
+      - "5601:5601"
     depends_on:
       - elasticsearch
     networks:
       - elastic
+
+  redis:
+    image: "redis:7"
+    container_name: mossy-redis
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+    networks:
+      - elastic
+
 networks:
   elastic:
     driver: bridge
+
+volumes:
+  redis-data:

--- a/src/main/java/backend/mossy/boundedContext/auth/app/AuthFacade.java
+++ b/src/main/java/backend/mossy/boundedContext/auth/app/AuthFacade.java
@@ -8,6 +8,7 @@ import backend.mossy.boundedContext.member.domain.User;
 import backend.mossy.boundedContext.member.out.user.UserRepository;
 import backend.mossy.global.exception.DomainException;
 import backend.mossy.global.exception.ErrorCode;
+import backend.mossy.shared.member.domain.role.RoleCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,6 @@ public class AuthFacade {
     private final RefreshTokenUseCase refreshTokenUseCase;
     private final TokenIssuer tokenIssuer;
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
 
     //로그인
     @Transactional
@@ -45,9 +45,7 @@ public class AuthFacade {
         User user = userRepository.findByIdWithRoles(userId)
                 .orElseThrow(() -> new DomainException(ErrorCode.USER_NOT_FOUND));
 
-        String role = user.getUserRoles() == null || user.getUserRoles().isEmpty()
-                ? "USER"
-                : user.getUserRoles().get(0).getRole().getCode().name();
+        String role = user.getPrimaryRole().name();
 
         TokenResponse tokens = tokenIssuer.issueTokens(userId,role);
 

--- a/src/main/java/backend/mossy/boundedContext/auth/in/AuthController.java
+++ b/src/main/java/backend/mossy/boundedContext/auth/in/AuthController.java
@@ -26,9 +26,6 @@ public class AuthController {
             description = "일반 유저(USER)로 가입")
     @PostMapping("/signup")
     public RsData<Long> signup(@RequestBody SignupRequest request) {
-        System.out.println(">>> request.longitude = " + request.longitude());
-        System.out.println(">>> request.latitude = " + request.latitude());
-
         return RsData.success("회원가입 성공", userFacade.signup(request));
     }
 

--- a/src/main/java/backend/mossy/boundedContext/auth/infra/config/RedisConfig.java
+++ b/src/main/java/backend/mossy/boundedContext/auth/infra/config/RedisConfig.java
@@ -4,24 +4,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        //Key, Value 모두 문자열로 저장 (가독성을 위해)
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-
-        //Hash Key/Value도 문자열
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new StringRedisSerializer());
-
-        return template;
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
     }
 }

--- a/src/main/java/backend/mossy/boundedContext/auth/out/RefreshTokenRepository.java
+++ b/src/main/java/backend/mossy/boundedContext/auth/out/RefreshTokenRepository.java
@@ -2,29 +2,37 @@ package backend.mossy.boundedContext.auth.out;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
 public class RefreshTokenRepository {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     private static final String KEY_TOKEN = "RT:TOKEN:";
     private static final String KEY_USER = "RT:USER:";
 
     public void save(String userId, String refreshToken, long ttlMillis) {
 
-        redisTemplate.opsForValue().set(KEY_TOKEN + refreshToken, userId, Duration.ofMillis(ttlMillis));
-        redisTemplate.opsForSet().add(KEY_USER + userId, refreshToken);
-        redisTemplate.expire(KEY_USER + userId, Duration.ofMillis(ttlMillis));
+        String tokenKey = KEY_TOKEN + refreshToken;
+        String userKey = KEY_USER + userId;
+
+        redisTemplate.opsForValue().set(tokenKey, userId, Duration.ofMillis(ttlMillis));
+        redisTemplate.opsForSet().add(userKey, refreshToken);
+        redisTemplate.expire(userKey, Duration.ofMillis(ttlMillis));
     }
 
     public String getUserIdByToken(String refreshToken) {
-        Object result = redisTemplate.opsForValue().get(KEY_TOKEN + refreshToken);
-        return result != null ? result.toString() : null;
+        String result = redisTemplate.opsForValue().get(KEY_TOKEN + refreshToken);
+        return result;
     }
 
     public boolean existsInUserSet(String userId, String refreshToken) {
@@ -39,14 +47,16 @@ public class RefreshTokenRepository {
     }
 
     public void deleteAllByUser(String userId) {
-        var tokens = redisTemplate.opsForSet().members(KEY_USER + userId);
+        String userKey = KEY_USER + userId;
+        Set<String> tokens = redisTemplate.opsForSet().members(userKey);
 
         if (tokens != null && !tokens.isEmpty()) {
-            for (Object token : tokens) {
-                redisTemplate.delete(KEY_TOKEN + token.toString());
+            List<String> keyToDelete = new ArrayList<>();
+            for (String token : tokens) {
+                keyToDelete.add(KEY_TOKEN + token);
             }
+            redisTemplate.delete(keyToDelete);
         }
-
-        redisTemplate.delete(KEY_USER + userId);
+        redisTemplate.delete(userKey);
     }
 }

--- a/src/main/java/backend/mossy/boundedContext/member/app/user/SignupUseCase.java
+++ b/src/main/java/backend/mossy/boundedContext/member/app/user/SignupUseCase.java
@@ -33,9 +33,6 @@ public class SignupUseCase {
             throw new DomainException(ErrorCode.DUPLICATE_NICKNAME);
         }
 
-        System.out.println(">>> DTO longitude = " + req.longitude());
-        System.out.println(">>> DTO latitude  = " + req.latitude());
-
         User user = User.builder()
                 .email(req.email())
                 .password(passwordEncoder.encode(req.password()))
@@ -49,9 +46,6 @@ public class SignupUseCase {
                 .profileImage("default.png")
                 .status(UserStatus.ACTIVE)
                 .build();
-
-        System.out.println(">>> ENTITY longitude = " + user.getLongitude());
-        System.out.println(">>> ENTITY latitude  = " + user.getLatitude());
 
         Role roleUser = roleRepository.findByCode(RoleCode.USER)
                 .orElseThrow(() -> new DomainException(ErrorCode.ROLE_NOT_FOUND));

--- a/src/main/java/backend/mossy/boundedContext/member/app/user/SignupUseCase.java
+++ b/src/main/java/backend/mossy/boundedContext/member/app/user/SignupUseCase.java
@@ -54,7 +54,7 @@ public class SignupUseCase {
         System.out.println(">>> ENTITY latitude  = " + user.getLatitude());
 
         Role roleUser = roleRepository.findByCode(RoleCode.USER)
-                .orElseThrow(() -> new DomainException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new DomainException(ErrorCode.ROLE_NOT_FOUND));
 
         user.addUserRole(new UserRole(user, roleUser));
 

--- a/src/main/java/backend/mossy/boundedContext/member/app/user/UserFacade.java
+++ b/src/main/java/backend/mossy/boundedContext/member/app/user/UserFacade.java
@@ -31,7 +31,7 @@ public class UserFacade {
         eventPublisher.publish(new UserJoinedEvent (userDto));
         log.info("UserJoinedEvent 발행 완료: userId ={}", user.getId());
 
-        return userRepository.save(user).getId();
+        return saved.getId();
 
 
     }

--- a/src/main/java/backend/mossy/boundedContext/member/domain/User.java
+++ b/src/main/java/backend/mossy/boundedContext/member/domain/User.java
@@ -1,8 +1,10 @@
 package backend.mossy.boundedContext.member.domain;
 
+import backend.mossy.shared.member.domain.role.RoleCode;
 import backend.mossy.shared.member.domain.role.UserRole;
 import backend.mossy.shared.member.domain.user.SourceUser;
 import backend.mossy.shared.member.domain.user.UserStatus;
+import co.elastic.clients.elasticsearch.cat.AliasesRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -51,4 +53,12 @@ public class User extends SourceUser {
         this.password = encodedPassword;
     }
 
+    public RoleCode getPrimaryRole() {
+       if (userRoles == null ||  userRoles.isEmpty()) return RoleCode.USER;
+
+       return userRoles.stream()
+               .map(ur -> ur.getRole().getCode())
+               .max(Enum::compareTo)
+               .orElse(RoleCode.USER);
+    }
 }

--- a/src/main/java/backend/mossy/shared/member/domain/role/RoleCode.java
+++ b/src/main/java/backend/mossy/shared/member/domain/role/RoleCode.java
@@ -1,5 +1,5 @@
 package backend.mossy.shared.member.domain.role;
 
 public enum RoleCode {
-    USER,SELLER, ADMIN
+    USER,SELLER,ADMIN
 }


### PR DESCRIPTION
## 📑 이슈 번호
- close #91

## ✨️ 작업 내용
- 로그인 시 Refresh Token을 Redis에 저장하도록 구현
- Refresh Token → userId 역방향 조회 로직 추가
- 사용자별 Refresh Token Set(`RT:USER:{userId}`) 관리
- 토큰 재발급 시 기존 Refresh Token 삭제 후 신규 발급 처리
- Redis 연결 설정(port) 정리 및 정상 동작 확인

## 💙 코멘트
- Refresh Token 저장 구조를 `RT:TOKEN:{refreshToken}` / `RT:USER:{userId}` 2-Key 전략으로 구성했습니다.
- 다중 디바이스 로그인 및 이후 Rotation 확장을 고려한 구조입니다.
- Redis TTL 관리 및 재사용 공격 방지(RTR)는 후속 작업으로 확장 가능합니다.

## 📸 구현 결과 (?)
<img width="567" height="255" alt="스크린샷 2026-01-24 오후 3 55 28" src="https://github.com/user-attachments/assets/4cae3dea-3003-414c-b4c9-8e9eeb750842" />

> 로그인 성공 시 Redis에 Refresh Token 저장 확인

<img width="571" height="50" alt="스크린샷 2026-01-24 오후 3 53 54" src="https://github.com/user-attachments/assets/100fd4aa-f860-4ebf-aa0f-db1daf7d6181" />

>`GET RT:TOKEN:{refreshToken}`으로 userId 정상 조회
