### PR TITLE
[Fix] #119 주문 생성 API 수정

### DIFF
--- a/common/src/main/java/com/mossy/shared/market/enums/OrderState.java
+++ b/common/src/main/java/com/mossy/shared/market/enums/OrderState.java
@@ -2,6 +2,7 @@ package com.mossy.shared.market.enums;
 
 public enum OrderState {
     PENDING,
+    EXPIRED,
     PAID,
     FAILED,
     CANCELED,

--- a/common/src/main/java/com/mossy/shared/member/event/SellerJoinedEvent.java
+++ b/common/src/main/java/com/mossy/shared/member/event/SellerJoinedEvent.java
@@ -1,6 +1,6 @@
 package com.mossy.shared.member.event;
 
-import com.mossy.shared.member.dto.event.SellerPayload;
+import com.mossy.shared.member.payload.SellerPayload;
 import lombok.Builder;
 
 @Builder

--- a/common/src/main/java/com/mossy/shared/member/event/SellerUpdatedEvent.java
+++ b/common/src/main/java/com/mossy/shared/member/event/SellerUpdatedEvent.java
@@ -1,6 +1,6 @@
 package com.mossy.shared.member.event;
 
-import com.mossy.shared.member.dto.event.SellerPayload;
+import com.mossy.shared.member.payload.SellerPayload;
 
 public record SellerUpdatedEvent(
         SellerPayload seller

--- a/common/src/main/java/com/mossy/shared/member/payload/SellerPayload.java
+++ b/common/src/main/java/com/mossy/shared/member/payload/SellerPayload.java
@@ -1,4 +1,4 @@
-package com.mossy.shared.member.dto.event;
+package com.mossy.shared.member.payload;
 
 import com.mossy.shared.member.domain.enums.SellerStatus;
 import com.mossy.shared.member.domain.enums.SellerType;

--- a/common/src/main/java/com/mossy/shared/payout/event/PayoutSellerCreatedEvent.java
+++ b/common/src/main/java/com/mossy/shared/payout/event/PayoutSellerCreatedEvent.java
@@ -1,7 +1,6 @@
 package com.mossy.shared.payout.event;
 
-import com.mossy.shared.member.dto.event.SellerPayload;
-
+import com.mossy.shared.member.payload.SellerPayload;
 
 public record PayoutSellerCreatedEvent(SellerPayload seller) {
 }

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/AddCartItemUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/AddCartItemUseCase.java
@@ -9,6 +9,7 @@ import com.mossy.boundedContext.marketUser.domain.MarketPolicy;
 import com.mossy.boundedContext.product.out.ProductApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class AddCartItemUseCase {
     private final CartRepository cartRepository;
     private final ProductApiClient productApiClient;
 
+    @Transactional
     public void addItem(Long userId, CartItemAddRequest request) {
         if (!productApiClient.exists(request.productId())) {
             throw new DomainException(ErrorCode.PRODUCT_NOT_FOUND);

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/CartFacade.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/CartFacade.java
@@ -6,7 +6,8 @@ import com.mossy.boundedContext.cart.in.dto.response.CartResponse;
 import com.mossy.shared.market.dto.event.MarketUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,33 +19,31 @@ public class CartFacade {
     private final ClearCartUseCase clearCartUseCase;
     private final GetCartItemListUseCase getCartItemListUseCase;
 
-    @Transactional(readOnly = true)
     public CartResponse getCart(Long userId) {
         return getCartItemListUseCase.getCart(userId);
     }
 
-    @Transactional
     public void createCart(MarketUserDto buyer) {
         createCartUseCase.create(buyer);
     }
 
-    @Transactional
     public void addCartItem(Long userId, CartItemAddRequest request) {
         addCartItemUseCase.addItem(userId, request);
     }
 
-    @Transactional
     public void updateCartItem(Long userId, CartItemUpdateRequest request) {
         updateCartItemUseCase.updateItemQuantity(userId, request);
     }
 
-    @Transactional
     public void removeCartItem(Long userId, Long productId) {
         removeCartItemUseCase.removeItem(userId, productId);
     }
 
-    @Transactional
     public void clearCart(Long userId) {
         clearCartUseCase.clear(userId);
+    }
+
+    public void removeCartItems(Long userId, List<Long> productIds) {
+        removeCartItemUseCase.removeItems(userId, productIds);
     }
 }

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/ClearCartUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/ClearCartUseCase.java
@@ -4,6 +4,7 @@ import com.mossy.boundedContext.cart.domain.Cart;
 import com.mossy.boundedContext.cart.out.CartRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,6 +12,7 @@ public class ClearCartUseCase {
 
     private final CartRepository cartRepository;
 
+    @Transactional
     public void clear(Long userId) {
         cartRepository.findByBuyerId(userId).ifPresent(Cart::clear);
     }

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/CreateCartUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/CreateCartUseCase.java
@@ -7,6 +7,7 @@ import com.mossy.boundedContext.marketUser.out.MarketUserRepository;
 import com.mossy.shared.market.dto.event.MarketUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class CreateCartUseCase {
     private final MarketUserRepository marketUserRepository;
     private final CartRepository cartRepository;
 
+    @Transactional
     public void create(MarketUserDto buyer) {
         MarketUser user = marketUserRepository.getReferenceById(buyer.id());
         Cart cart = Cart.createCart(user);

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/GetCartItemListUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/GetCartItemListUseCase.java
@@ -5,11 +5,11 @@ import com.mossy.boundedContext.cart.in.dto.response.CartResponse;
 import com.mossy.boundedContext.cart.out.CartRepository;
 import com.mossy.boundedContext.exception.DomainException;
 import com.mossy.boundedContext.exception.ErrorCode;
-import com.mossy.boundedContext.marketUser.out.MarketSellerRepository;
 import com.mossy.boundedContext.product.in.dto.response.ProductInfoResponse;
 import com.mossy.boundedContext.product.out.ProductApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,8 +19,8 @@ public class GetCartItemListUseCase {
 
     private final CartRepository cartRepository;
     private final ProductApiClient productApiClient;
-    private final MarketSellerRepository marketSellerRepository;
 
+    @Transactional(readOnly = true)
     public CartResponse getCart(Long userId) {
         Cart cart = cartRepository.findByBuyerId(userId).orElseThrow(
                 () -> new DomainException(ErrorCode.CART_NOT_FOUND));

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/RemoveCartItemUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/RemoveCartItemUseCase.java
@@ -4,8 +4,11 @@ import com.mossy.boundedContext.cart.domain.Cart;
 import com.mossy.boundedContext.cart.out.CartRepository;
 import com.mossy.boundedContext.exception.DomainException;
 import com.mossy.boundedContext.exception.ErrorCode;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,10 +16,19 @@ public class RemoveCartItemUseCase {
 
     private final CartRepository cartRepository;
 
+    @Transactional
     public void removeItem(Long userId, Long productId) {
         Cart cart = cartRepository.findByBuyerId(userId)
                 .orElseThrow(() -> new DomainException(ErrorCode.CART_NOT_FOUND));
 
         cart.removeItem(productId);
+    }
+
+    @Transactional
+    public void removeItems(Long userId, List<Long> productIds) {
+        Cart cart = cartRepository.findByBuyerId(userId)
+                .orElseThrow(() -> new DomainException(ErrorCode.CART_NOT_FOUND));
+
+        cart.removeItems(productIds);
     }
 }

--- a/market/src/main/java/com/mossy/boundedContext/cart/app/UpdateCartItemQuantityUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/app/UpdateCartItemQuantityUseCase.java
@@ -8,6 +8,7 @@ import com.mossy.boundedContext.exception.ErrorCode;
 import com.mossy.boundedContext.marketUser.domain.MarketPolicy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +17,7 @@ public class UpdateCartItemQuantityUseCase {
     private final CartRepository cartRepository;
     private final MarketPolicy marketPolicy;
 
+    @Transactional
     public void updateItemQuantity(Long userId, CartItemUpdateRequest request) {
         Cart cart = cartRepository.findByBuyerId(userId)
                 .orElseThrow(() -> new DomainException(ErrorCode.CART_NOT_FOUND));

--- a/market/src/main/java/com/mossy/boundedContext/cart/domain/CartItem.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/domain/CartItem.java
@@ -24,10 +24,10 @@ public class CartItem extends BaseIdAndTime {
     @Column(nullable = false)
     private int quantity;
 
-    public CartItem(Cart cart, Long productId, int count) {
+    public CartItem(Cart cart, Long productId, int quantity) {
         this.cart = cart;
         this.productId = productId;
-        this.quantity = count;
+        this.quantity = quantity;
     }
 
     public void addItem(int quantity) {

--- a/market/src/main/java/com/mossy/boundedContext/cart/in/ApiV1CartController.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/in/ApiV1CartController.java
@@ -2,6 +2,7 @@ package com.mossy.boundedContext.cart.in;
 
 import com.mossy.boundedContext.cart.app.CartFacade;
 import com.mossy.boundedContext.cart.in.dto.request.CartItemAddRequest;
+import com.mossy.boundedContext.cart.in.dto.request.CartItemDeleteRequest;
 import com.mossy.boundedContext.cart.in.dto.request.CartItemUpdateRequest;
 import com.mossy.boundedContext.cart.in.dto.response.CartResponse;
 import com.mossy.global.rsData.RsData;
@@ -62,21 +63,30 @@ public class ApiV1CartController {
         return new RsData<>("200", "장바구니 상품 수량이 수정되었습니다.");
     }
 
-
     @Operation(
-            summary = "장바구니 상품 삭제",
-            description = "장바구니에서 특정 상품을 삭제합니다."
+            summary = "장바구니 상품 단일 삭제",
+            description = "장바구니에 담긴 상품을 삭제합니다."
     )
     @DeleteMapping("/items/{productId}")
     public RsData<Void> removeCartItem(
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId,
-
-            @Parameter(description = "삭제할 상품 ID", required = true)
             @PathVariable Long productId
     ) {
         cartFacade.removeCartItem(userId, productId);
-        return new RsData<>("200", "장바구니에서 상품이 삭제되었습니다.");
+        return new RsData<>("200", "상품이 삭제되었습니다.");
+    }
+
+    @Operation(
+            summary = "장바구니 상품 선택 삭제",
+            description = "장바구니에 담긴 선택한 상품들을 삭제합니다."
+    )
+    @DeleteMapping("/items")
+    public RsData<Void> removeCartItems(
+            @RequestParam(name="userId") Long userId,
+            @RequestBody CartItemDeleteRequest request
+    ) {
+        cartFacade.removeCartItems(userId, request.productIds());
+        return new RsData<>("200", "선택한 상품들이 삭제되었습니다.");
     }
 
     @Operation(

--- a/market/src/main/java/com/mossy/boundedContext/cart/in/ApiV1CartController.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/in/ApiV1CartController.java
@@ -25,7 +25,6 @@ public class ApiV1CartController {
     )
     @GetMapping
     public RsData<CartResponse> getCart(
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId
     ) {
         return new RsData<>("200", "장바구니 조회를 성공했습니다.", cartFacade.getCart(userId));
@@ -37,7 +36,7 @@ public class ApiV1CartController {
     )
     @PostMapping("/items")
     public RsData<Void> addCartItem(
-            @Parameter(hidden = true)
+            @Parameter(description = "사용자 ID")
             @RequestParam(name="userId") Long userId,
 
             @Parameter(description = "장바구니 상품 추가 요청 DTO", required = true)
@@ -95,7 +94,6 @@ public class ApiV1CartController {
     )
     @DeleteMapping
     public RsData<Void> clearCart(
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId
     ) {
         cartFacade.clearCart(userId);

--- a/market/src/main/java/com/mossy/boundedContext/cart/in/dto/request/CartItemDeleteRequest.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/in/dto/request/CartItemDeleteRequest.java
@@ -1,0 +1,7 @@
+package com.mossy.boundedContext.cart.in.dto.request;
+
+import java.util.List;
+
+public record CartItemDeleteRequest(
+        List<Long> productIds
+) { }

--- a/market/src/main/java/com/mossy/boundedContext/cart/in/dto/response/CartResponse.java
+++ b/market/src/main/java/com/mossy/boundedContext/cart/in/dto/response/CartResponse.java
@@ -9,7 +9,6 @@ import java.util.List;
 @Builder
 public record CartResponse(
         Long cartId,
-        String buyerName,
         String buyerAddress,
         int itemCount,
         List<ProductInfoResponse> items
@@ -18,7 +17,6 @@ public record CartResponse(
     public static CartResponse of(Cart cart, List<ProductInfoResponse> items) {
         return CartResponse.builder()
                 .cartId(cart.getId())
-                .buyerName(cart.getBuyer().getName())
                 .buyerAddress(cart.getBuyer().getAddress())
                 .itemCount(items.size())
                 .items(items)

--- a/market/src/main/java/com/mossy/boundedContext/infra/scheduler/OrderExpireDeleteScheduler.java
+++ b/market/src/main/java/com/mossy/boundedContext/infra/scheduler/OrderExpireDeleteScheduler.java
@@ -2,7 +2,6 @@ package com.mossy.boundedContext.infra.scheduler;
 
 import com.mossy.boundedContext.order.domain.Order;
 import com.mossy.boundedContext.order.out.OrderRepository;
-import com.mossy.shared.market.enums.OrderState;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/market/src/main/java/com/mossy/boundedContext/infra/scheduler/OrderExpireDeleteScheduler.java
+++ b/market/src/main/java/com/mossy/boundedContext/infra/scheduler/OrderExpireDeleteScheduler.java
@@ -1,0 +1,38 @@
+package com.mossy.boundedContext.infra.scheduler;
+
+import com.mossy.boundedContext.order.domain.Order;
+import com.mossy.boundedContext.order.out.OrderRepository;
+import com.mossy.shared.market.enums.OrderState;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OrderExpireDeleteScheduler {
+
+    private final OrderRepository orderRepository;
+
+    // 매일 자정에 실행
+    // 결제되지 않은 주문을 일주일 뒤 삭제
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteExpiredOrders() {
+        LocalDateTime threshold = LocalDateTime.now().minusWeeks(1);
+        orderRepository.deleteExpiredOrders(threshold);
+    }
+
+    // 10분마다 실행
+    // 주문 생성 후 30분이 지나도 PENDING인 주문은 EXPIRED로 업데이트
+    @Transactional
+    @Scheduled(cron = "0 */10 * * * *")
+    public void updateExpiredOrders() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(30);
+        List<Order> expiredOrders = orderRepository.findPendingOrdersCreatedBefore(threshold);
+        expiredOrders.forEach(Order::expire);
+    }
+}

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketFacade.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketFacade.java
@@ -2,7 +2,7 @@ package com.mossy.boundedContext.marketUser.app;
 
 import com.mossy.boundedContext.marketUser.domain.MarketSeller;
 import com.mossy.boundedContext.marketUser.domain.MarketUser;
-import com.mossy.shared.member.dto.event.SellerPayload;
+import com.mossy.shared.member.payload.SellerPayload;
 import com.mossy.shared.member.payload.UserPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketFacade.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketFacade.java
@@ -18,7 +18,6 @@ public class MarketFacade {
         return marketSyncUserUseCase.syncUser(user);
     }
 
-    @Transactional
     public MarketSeller syncSeller(SellerPayload seller) {
         return marketSyncSellerUseCase.syncSeller(seller);
     }

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketSyncSellerUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketSyncSellerUseCase.java
@@ -2,28 +2,26 @@ package com.mossy.boundedContext.marketUser.app;
 
 import com.mossy.boundedContext.marketUser.domain.MarketSeller;
 import com.mossy.boundedContext.marketUser.out.MarketSellerRepository;
-import com.mossy.global.eventPublisher.EventPublisher;
-import com.mossy.shared.market.event.MarketSellerCreatedEvent;
-import com.mossy.shared.member.dto.event.SellerPayload;
+import com.mossy.shared.member.payload.SellerPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MarketSyncSellerUseCase {
 
     private final MarketSellerRepository marketSellerRepository;
-    private final EventPublisher eventPublisher;
 
+    @Transactional
     public MarketSeller syncSeller(SellerPayload seller) {
-        boolean isNew = !marketSellerRepository.existsById(seller.sellerId());
-
-        MarketSeller marketSeller = marketSellerRepository.save(MarketSeller.from(seller));
-
-        if (isNew) {
-            eventPublisher.publish(new MarketSellerCreatedEvent(marketSeller.toDto()));
-        }
-
-        return marketSeller;
+        return marketSellerRepository.findById(seller.sellerId())
+                .map(existingSeller -> {
+                    existingSeller.updateSeller(seller);
+                    return existingSeller;
+                })
+                .orElseGet(() -> {
+                    return marketSellerRepository.save(MarketSeller.from(seller));
+                });
     }
 }

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketSyncSellerUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/app/MarketSyncSellerUseCase.java
@@ -16,12 +16,12 @@ public class MarketSyncSellerUseCase {
     @Transactional
     public MarketSeller syncSeller(SellerPayload seller) {
         return marketSellerRepository.findById(seller.sellerId())
-                .map(existingSeller -> {
-                    existingSeller.updateSeller(seller);
-                    return existingSeller;
-                })
-                .orElseGet(() -> {
-                    return marketSellerRepository.save(MarketSeller.from(seller));
-                });
+            .map(existingSeller -> {
+                existingSeller.updateSeller(seller);
+                return existingSeller;
+            })
+            .orElseGet(() -> {
+                return marketSellerRepository.save(MarketSeller.from(seller));
+            });
     }
 }

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/domain/MarketSeller.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/domain/MarketSeller.java
@@ -3,7 +3,7 @@ package com.mossy.boundedContext.marketUser.domain;
 import com.mossy.shared.market.dto.event.MarketSellerDto;
 import com.mossy.shared.member.domain.enums.SellerStatus;
 import com.mossy.shared.member.domain.enums.SellerType;
-import com.mossy.shared.member.dto.event.SellerPayload;
+import com.mossy.shared.member.payload.SellerPayload;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -77,5 +77,9 @@ public class MarketSeller extends ReplicaSeller {
                 .createdAt(getCreatedAt())
                 .updatedAt(getUpdatedAt())
                 .build();
+    }
+
+    public void updateSeller(SellerPayload seller) {
+        super.changeSeller(seller);
     }
 }

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/domain/ReplicaSeller.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/domain/ReplicaSeller.java
@@ -3,6 +3,7 @@ package com.mossy.boundedContext.marketUser.domain;
 import com.mossy.shared.member.domain.entity.BaseSeller;
 import com.mossy.shared.member.domain.enums.SellerStatus;
 import com.mossy.shared.member.domain.enums.SellerType;
+import com.mossy.shared.member.payload.SellerPayload;
 import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
@@ -52,6 +53,17 @@ public abstract class ReplicaSeller extends BaseSeller {
         this.id = id;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    protected void changeSeller(SellerPayload seller) {
+        this.id = seller.sellerId();
+        this.sellerType = seller.sellerType();
+        this.storeName = seller.storeName();
+        this.businessNum = seller.businessNum();
+        this.latitude = seller.latitude();
+        this.longitude = seller.longitude();
+        this.status = seller.status();
+        this.updatedAt = seller.updatedAt();
     }
 }
 

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/domain/ReplicaUser.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/domain/ReplicaUser.java
@@ -44,7 +44,7 @@ public abstract class ReplicaUser extends BaseUser {
         this.updatedAt = updatedAt;
     }
 
-    public void changeUser(UserPayload payload) {
+    protected void changeUser(UserPayload payload) {
         this.email = payload.email();
         this.name = payload.name();
         this.address = payload.address();

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/in/DataInit.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/in/DataInit.java
@@ -1,0 +1,69 @@
+package com.mossy.boundedContext.marketUser.in;
+
+import com.mossy.global.eventPublisher.EventPublisher;
+import com.mossy.shared.member.domain.enums.UserStatus;
+import com.mossy.shared.member.event.UserJoinedEvent;
+import com.mossy.shared.member.event.UserUpdatedEvent;
+import com.mossy.shared.member.payload.UserPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataInit {
+    private final DataInitService dataInitService;
+
+    @Bean
+    public ApplicationRunner memberDataInitApplicationRunner() {
+        return args -> dataInitService.init();
+    }
+}
+
+@Service
+@RequiredArgsConstructor
+class DataInitService {
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    public void init() {
+        UserPayload payload = UserPayload.builder()
+                .id(2L)
+                .email("test@example.com")
+                .name("홍길동")
+                .address("서울시 강남구")
+                .nickname("모시모시")
+                .profileImage("https://example.com/default.png")
+                .status(UserStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .latitude(new BigDecimal("37.5665"))
+                .longitude(new BigDecimal("126.9780"))
+                .build();
+
+        eventPublisher.publish(new UserJoinedEvent(payload));
+
+
+        payload = UserPayload.builder()
+                .id(2L)
+                .email("test@example.com")
+                .name("홍길동")
+                .address("서울시 서초구")
+                .nickname("모시모시")
+                .profileImage("https://example.com/default.png")
+                .status(UserStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .latitude(new BigDecimal("37.5665"))
+                .longitude(new BigDecimal("126.9780"))
+                .build();
+
+        eventPublisher.publish(new UserUpdatedEvent(payload));
+    }
+}

--- a/market/src/main/java/com/mossy/boundedContext/marketUser/out/MarketUserRepository.java
+++ b/market/src/main/java/com/mossy/boundedContext/marketUser/out/MarketUserRepository.java
@@ -1,7 +1,17 @@
 package com.mossy.boundedContext.marketUser.out;
 
 import com.mossy.boundedContext.marketUser.domain.MarketUser;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MarketUserRepository extends JpaRepository<MarketUser, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from MarketUser u where u.id = :userId")
+    Optional<MarketUser> findByIdWithLock(@Param("userId") Long userId);
 }

--- a/market/src/main/java/com/mossy/boundedContext/order/app/CreateOrderUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/app/CreateOrderUseCase.java
@@ -1,5 +1,7 @@
 package com.mossy.boundedContext.order.app;
 
+import com.mossy.boundedContext.exception.DomainException;
+import com.mossy.boundedContext.exception.ErrorCode;
 import com.mossy.boundedContext.marketUser.domain.MarketPolicy;
 import com.mossy.boundedContext.marketUser.domain.MarketSeller;
 import com.mossy.boundedContext.marketUser.domain.MarketUser;
@@ -30,10 +32,13 @@ public class CreateOrderUseCase {
 
     @Transactional
     public OrderCreatedResponse createOrder(Long userId, OrderCreatedRequest request) {
+        MarketUser buyer = marketUserRepository.findByIdWithLock(userId)
+                .orElseThrow(() -> new DomainException(ErrorCode.BUYER_NOT_FOUND));
+
         orderRepository.findByBuyerIdAndState(userId, OrderState.PENDING)
                 .ifPresent(Order::expire);
 
-        MarketUser buyer = marketUserRepository.getReferenceById(userId);
+        // TODO: 재고 조회
 
         String orderNo = marketPolicy.generateOrderNo();
 
@@ -46,14 +51,14 @@ public class CreateOrderUseCase {
                 .collect(Collectors.toMap(MarketSeller::getId, seller -> seller));
 
         Order savedOrder = orderRepository.save(
-            Order.create(
-                    buyer,
-                    request.buyerAddress(),
-                    orderNo,
-                    sellerMap,
-                    request.items(),
-                    request.totalPrice()
-            )
+                Order.create(
+                        buyer,
+                        request.buyerAddress(),
+                        orderNo,
+                        sellerMap,
+                        request.items(),
+                        request.totalPrice()
+                )
         );
 
         return OrderCreatedResponse.builder()

--- a/market/src/main/java/com/mossy/boundedContext/order/app/CreateOrderUseCase.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/app/CreateOrderUseCase.java
@@ -1,7 +1,5 @@
 package com.mossy.boundedContext.order.app;
 
-import com.mossy.boundedContext.exception.DomainException;
-import com.mossy.boundedContext.exception.ErrorCode;
 import com.mossy.boundedContext.marketUser.domain.MarketPolicy;
 import com.mossy.boundedContext.marketUser.domain.MarketSeller;
 import com.mossy.boundedContext.marketUser.domain.MarketUser;
@@ -12,13 +10,13 @@ import com.mossy.boundedContext.order.in.dto.request.OrderCreatedRequest;
 import com.mossy.boundedContext.order.in.dto.response.OrderCreatedResponse;
 import com.mossy.boundedContext.order.out.OrderRepository;
 import com.mossy.boundedContext.product.in.dto.response.ProductInfoResponse;
-import com.mossy.global.eventPublisher.EventPublisher;
+import com.mossy.shared.market.enums.OrderState;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,33 +28,33 @@ public class CreateOrderUseCase {
     private final OrderRepository orderRepository;
     private final MarketPolicy marketPolicy;
 
+    @Transactional
     public OrderCreatedResponse createOrder(Long userId, OrderCreatedRequest request) {
-        MarketUser buyer = marketUserRepository.findById(userId)
-                .orElseThrow(() -> new DomainException(ErrorCode.USER_NOT_FOUND));
+        orderRepository.findByBuyerIdAndState(userId, OrderState.PENDING)
+                .ifPresent(Order::expire);
+
+        MarketUser buyer = marketUserRepository.getReferenceById(userId);
 
         String orderNo = marketPolicy.generateOrderNo();
 
-        // 1. order 생성
-        Order order = Order.create(buyer, orderNo);
-
-        // 2. sellerId 추출
         List<Long> sellerIds = request.items().stream()
                 .map(ProductInfoResponse::sellerId)
                 .distinct()
                 .toList();
 
-        // 3. 판매자 조회
         Map<Long, MarketSeller> sellerMap = marketSellerRepository.findAllById(sellerIds).stream()
-                .collect(Collectors.toMap(MarketSeller::getId, Function.identity()));
+                .collect(Collectors.toMap(MarketSeller::getId, seller -> seller));
 
-        // 6. OrderDetail 생성
-        for (ProductInfoResponse item : request.items()) {
-            MarketSeller seller = sellerMap.get(item.sellerId());
-            order.addOrderDetail(seller, item.productId(), item.quantity(), item.price());
-        }
-
-        // 7. 저장
-        Order savedOrder = orderRepository.save(order);
+        Order savedOrder = orderRepository.save(
+            Order.create(
+                    buyer,
+                    request.buyerAddress(),
+                    orderNo,
+                    sellerMap,
+                    request.items(),
+                    request.totalPrice()
+            )
+        );
 
         return OrderCreatedResponse.builder()
                 .orderId(savedOrder.getId())

--- a/market/src/main/java/com/mossy/boundedContext/order/domain/Order.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/domain/Order.java
@@ -4,6 +4,7 @@ import com.mossy.boundedContext.exception.DomainException;
 import com.mossy.boundedContext.exception.ErrorCode;
 import com.mossy.boundedContext.marketUser.domain.MarketSeller;
 import com.mossy.boundedContext.marketUser.domain.MarketUser;
+import com.mossy.boundedContext.product.in.dto.response.ProductInfoResponse;
 import com.mossy.global.jpa.entity.BaseIdAndTime;
 import com.mossy.shared.market.enums.OrderState;
 import jakarta.persistence.*;
@@ -12,6 +13,7 @@ import lombok.*;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -41,44 +43,45 @@ public class Order extends BaseIdAndTime {
     @Column(nullable = false)
     private OrderState state;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "order", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     @Builder.Default
     private List<OrderItem> orderItems = new ArrayList<>();
 
     public static Order create(
             MarketUser buyer,
-            String orderNo
+            String address,
+            String orderNo,
+            Map<Long, MarketSeller> sellerMap,
+            List<ProductInfoResponse> items,
+            BigDecimal totalPrice
     ) {
-        return Order.builder()
+        Order order = Order.builder()
                 .buyer(buyer)
                 .orderNo(orderNo)
-                .address(buyer.getAddress())
-                .totalPrice(BigDecimal.ZERO)
+                .address(address)
                 .state(OrderState.PENDING)
+                .totalPrice(totalPrice)
                 .build();
+
+        items.forEach(item -> order.addOrderItem(sellerMap.get(item.sellerId()), item));
+
+        return order;
     }
 
-    public void addOrderDetail(
-            MarketSeller seller,
-            Long productId,
-            int quantity,
-            BigDecimal price
-    ) {
-        BigDecimal orderPrice = price.multiply(BigDecimal.valueOf(quantity));
-        this.orderItems.add(
-                OrderItem.create(
-                        this,
-                        seller,
-                        productId,
-                        quantity,
-                        orderPrice
-                )
-        );
-        this.totalPrice = this.totalPrice.add(orderPrice);
+    private void addOrderItem(MarketSeller seller, ProductInfoResponse item) {
+        BigDecimal orderPrice = item.price().multiply(BigDecimal.valueOf(item.quantity()));
+        OrderItem orderItem = OrderItem.create(this, seller, item.productId(), item.quantity(), orderPrice);
+        this.orderItems.add(orderItem);
     }
 
     public void completePayment() {
         this.state = OrderState.PAID;
+    }
+
+    public void expire() {
+        if (this.state == OrderState.PENDING) {
+            this.state = OrderState.EXPIRED;
+        }
     }
 
     public void validateAmount(BigDecimal requestAmount) {

--- a/market/src/main/java/com/mossy/boundedContext/order/domain/OrderItem.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/domain/OrderItem.java
@@ -11,10 +11,10 @@ import java.math.BigDecimal;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
-@Table(name = "MARKET_ORDER_DETAIL")
+@Table(name = "MARKET_ORDER_ITEM")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@AttributeOverride(name = "id", column = @Column(name = "order_detail_id"))
+@AttributeOverride(name = "id", column = @Column(name = "order_item_id"))
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class OrderItem extends BaseIdAndTime {

--- a/market/src/main/java/com/mossy/boundedContext/order/in/ApiV1OrderController.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/in/ApiV1OrderController.java
@@ -31,7 +31,6 @@ public class ApiV1OrderController {
     )
     @PostMapping
     public RsData<OrderCreatedResponse> createOrder(
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId,
 
             @Parameter(description = "주문 생성 요청 DTO", required = true)
@@ -46,7 +45,6 @@ public class ApiV1OrderController {
     )
     @GetMapping
     public Page<OrderListResponse> getMyOrders(
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId,
 
             @Parameter(hidden = true)
@@ -74,7 +72,6 @@ public class ApiV1OrderController {
     @DeleteMapping("/{orderId}")
     public RsData<Void> deleteOrder(
             @PathVariable Long orderId,
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId
     ) {
         orderFacade.deleteOrder(orderId, userId);
@@ -89,7 +86,6 @@ public class ApiV1OrderController {
     public RsData<Void> cancelOrder(
             @Parameter(description = "주문 ID", required = true)
             @PathVariable Long orderId,
-            @Parameter(hidden = true)
             @RequestParam(name="userId") Long userId,
             @Parameter(description = "취소 사유", required = true)
             @RequestParam String cancelReason

--- a/market/src/main/java/com/mossy/boundedContext/order/in/dto/request/OrderCreatedRequest.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/in/dto/request/OrderCreatedRequest.java
@@ -8,9 +8,7 @@ import java.util.List;
 
 @Builder
 public record OrderCreatedRequest(
-//        String buyerAddress,
-//        BigDecimal buyerLatitude,
-//        BigDecimal buyerLongitude,
+        String buyerAddress,
         BigDecimal totalPrice,
         String paymentType,
         List<ProductInfoResponse> items

--- a/market/src/main/java/com/mossy/boundedContext/order/out/OrderRepository.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/out/OrderRepository.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 
 public interface OrderRepository  extends JpaRepository<Order, Long>, OrderRepositoryCustom{
 
-    Optional<Order> findByIdAndState(Long orderId, OrderState state);
-
     Optional<Order> findByBuyerIdAndState(Long buyerId, OrderState state);
 
     Optional<Order> findByOrderNo(String orderNo);

--- a/market/src/main/java/com/mossy/boundedContext/order/out/OrderRepository.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/out/OrderRepository.java
@@ -4,20 +4,40 @@ package com.mossy.boundedContext.order.out;
 import com.mossy.boundedContext.order.domain.Order;
 import com.mossy.shared.market.enums.OrderState;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+public interface OrderRepository  extends JpaRepository<Order, Long>, OrderRepositoryCustom{
 
     Optional<Order> findByIdAndState(Long orderId, OrderState state);
 
+    Optional<Order> findByBuyerIdAndState(Long buyerId, OrderState state);
+
     Optional<Order> findByOrderNo(String orderNo);
+
     @Query("SELECT o FROM Order o JOIN FETCH o.buyer WHERE o.id = :orderId")
     Optional<Order> findByIdWithBuyer(@Param("orderId") Long orderId);
 
     @Query("SELECT o FROM Order o JOIN FETCH o.buyer WHERE o.buyer.id = :userId")
     List<Order> findByBuyerIdWithBuyer(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("""
+    delete from Order o
+    where o.state = 'EXPIRED'
+    and o.createdAt < :threshold
+    """)
+    void deleteExpiredOrders(@Param("threshold") LocalDateTime threshold);
+
+    @Query("""
+    select o from Order o
+    where o.state = 'PENDING'
+    and o.createdAt < :threshold
+    """)
+    List<Order> findPendingOrdersCreatedBefore(@Param("threshold") LocalDateTime threshold);
 }

--- a/market/src/main/java/com/mossy/boundedContext/order/out/OrderRepositoryImpl.java
+++ b/market/src/main/java/com/mossy/boundedContext/order/out/OrderRepositoryImpl.java
@@ -52,7 +52,8 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 
     @Override
     public Page<OrderListResponse> findOrderListByUserId(Long userId, Pageable pageable) {
-        BooleanExpression condition = order.buyer.id.eq(userId);
+        BooleanExpression condition = order.buyer.id.eq(userId)
+                .and(order.state.notIn(OrderState.PENDING, OrderState.EXPIRED));
 
         List<OrderListResponse> content = queryFactory
                 .select(Projections.constructor(OrderListResponse.class,

--- a/market/src/main/java/com/mossy/boundedContext/product/domain/Product.java
+++ b/market/src/main/java/com/mossy/boundedContext/product/domain/Product.java
@@ -34,7 +34,6 @@ public class Product extends BaseIdAndTime {
     @Column(nullable = false, length = 255)
     private String name;
 
-    @Lob
     @Column(name = "description", nullable = false)
     private String description;
 

--- a/market/src/main/java/com/mossy/boundedContext/product/in/dto/response/ProductInfoResponse.java
+++ b/market/src/main/java/com/mossy/boundedContext/product/in/dto/response/ProductInfoResponse.java
@@ -11,7 +11,6 @@ public record ProductInfoResponse(
         String productName,
         String categoryName,
         BigDecimal price,
-        BigDecimal weight,
         String thumbnailUrl,
         Integer quantity
 ) { }

--- a/market/src/main/java/com/mossy/boundedContext/product/out/ProductRepositoryImpl.java
+++ b/market/src/main/java/com/mossy/boundedContext/product/out/ProductRepositoryImpl.java
@@ -27,7 +27,6 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.name,
                         category.name,
                         product.price,
-                        product.weight,
                         productImage.imageUrl,
                         cartItem.quantity
                 ))

--- a/market/src/main/resources/application.yml
+++ b/market/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
 
   jpa:
     open-in-view: false
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
## 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #119 

## ✨️ 작업 내용
- orderDetail -> orderItem 엔티티 변경

- order 생성 API 수정
(1) 주문 생성 후 결제를 하지 않고 장바구니를 수정한 뒤 다시 주문하는 경우 state를 EXPIRED로 변경
(2) EXPIRED된 주문은 스케쥴러를 통해서 매일 자정 일주일이 지난 EXPIRED 모두 삭제
(3) 30분이 지난 PENDING은 EXPIRED 처리

- 스케쥴러 생성
(1) PENDING -> EXPIRED 스케쥴러
(2) EXPIRED 주문 delete 스케쥴러

- 중복 주문 동시성 제어

- 비즈니스 흐름
구매하기 -> 결제하기 -> 주문생성 -> toss 호출 -> 결제완료

- 테스트 시나리오
1. 유저는 상품 A 1개를 장바구니에 담는다.
2. 구매하기 후, 결제하기를 클릭한다.
3. 유저는 장바구니에 상품 하나 더 담는 것을 깜빡해서 결제 진행 중 빠져나왔다.
4. 유저는 장바구니에 상품B를 10개 담았고, 상품A를 10개로 수정했다.
5. 유저는 구매하기 후 결제하기를 빠르게 더블클릭으로 눌렀다.

## 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

## 📸 구현 결과 (?)

<img width="939" height="540" alt="image" src="https://github.com/user-attachments/assets/8b244de3-1a19-42ce-b79d-e5c18759db2a" />

<img width="582" height="240" alt="image" src="https://github.com/user-attachments/assets/f372d24f-077d-4da8-82f3-0b3d3f0d273e" />

<img width="303" height="114" alt="image" src="https://github.com/user-attachments/assets/6c3a903e-e55d-497c-9745-1af122685d41" />

<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
