### PR TITLE
[Feature] #202 정산 단위 테스트 코드 작성

### DIFF
--- a/payout/build.gradle.kts
+++ b/payout/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "3.4.1"
     id("io.spring.dependency-management") version "1.1.7"
+    id("me.champeau.jmh") version "0.7.2"
 }
 
 group = "com.mossy"
@@ -60,6 +61,17 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+jmh {
+    jmhVersion = "1.37"
+    warmupIterations = 3
+    iterations = 5
+    fork = 1
+    timeUnit = "ms"          // 결과 단위: ms (AverageTime 기준)
+    benchmarkMode = listOf("thrpt", "avgt")  // 처리량 + 평균 시간 동시 측정
+    resultsFile = project.file("${project.buildDir}/reports/jmh/results.txt")
+    zip64 = true             // 클래스파일 65535개 초과 시 필요
 }
 
 springBoot {

--- a/payout/src/jmh/java/com/mossy/benchmark/CalculatorBenchmark.java
+++ b/payout/src/jmh/java/com/mossy/benchmark/CalculatorBenchmark.java
@@ -1,0 +1,196 @@
+package com.mossy.benchmark;
+
+import com.mossy.boundedContext.payout.domain.calculator.CarbonCalculator;
+import com.mossy.boundedContext.payout.domain.calculator.DonationCalculator;
+import com.mossy.boundedContext.payout.domain.calculator.FeeCalculator;
+import com.mossy.boundedContext.payout.domain.calculator.WeightCalculator;
+import com.mossy.boundedContext.payout.in.dto.command.PayoutCandidateCreateDto;
+import com.mossy.shared.payout.enums.CarbonGrade;
+import org.openjdk.jmh.annotations.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * [JMH Benchmark] 정산 계산기 성능 벤치마크
+ *
+ * 실행 방법:
+ *   ./gradlew :payout:jmh
+ *
+ * 결과 파일:
+ *   payout/build/reports/jmh/results.txt
+ *
+ * 측정 항목:
+ *   - Throughput(thrpt): 초당 처리 건수 (ops/ms)
+ *   - AverageTime(avgt): 1건당 평균 처리 시간 (ms)
+ */
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class CalculatorBenchmark {
+
+    private WeightCalculator weightCalculator;
+    private CarbonCalculator carbonCalculator;
+    private FeeCalculator feeCalculator;
+    private DonationCalculator donationCalculator;
+
+    // 시나리오별 DTO — 무게/거리/금액이 다른 3가지 케이스
+    private PayoutCandidateCreateDto dtoSmallNear;      // 소형 + 근거리 (탄소 최소)
+    private PayoutCandidateCreateDto dtoLargeIsland;    // 대형 + 도서제주 (탄소 최대)
+    private PayoutCandidateCreateDto dtoTypical;        // 중형 + 중거리 (일반 케이스)
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        // @Value 대신 setter로 static 필드 직접 주입
+        carbonCalculator = new CarbonCalculator();
+        carbonCalculator.setCarbonCoefficient(new BigDecimal("0.01"));
+
+        feeCalculator = new FeeCalculator(carbonCalculator);
+
+        donationCalculator = new DonationCalculator(carbonCalculator, feeCalculator);
+        donationCalculator.setMaxDonationRate(new BigDecimal("0.50"));
+
+        weightCalculator = new WeightCalculator();
+
+        // 시나리오 1: 소형 상품, 근거리 배송, 소액
+        dtoSmallNear = PayoutCandidateCreateDto.builder()
+                .orderPrice(new BigDecimal("5000"))
+                .weightGrade("소형")
+                .deliveryDistance(new BigDecimal("25"))
+                .paymentDate(LocalDateTime.of(2025, 1, 1, 12, 0))
+                .build();
+
+        // 시나리오 2: 대형 상품, 도서제주 배송, 고액
+        dtoLargeIsland = PayoutCandidateCreateDto.builder()
+                .orderPrice(new BigDecimal("500000"))
+                .weightGrade("대형")
+                .deliveryDistance(new BigDecimal("400"))
+                .paymentDate(LocalDateTime.of(2025, 1, 1, 12, 0))
+                .build();
+
+        // 시나리오 3: 중형 상품, 중거리 배송, 일반 금액
+        dtoTypical = PayoutCandidateCreateDto.builder()
+                .orderPrice(new BigDecimal("50000"))
+                .weightGrade("중형")
+                .deliveryDistance(new BigDecimal("200"))
+                .paymentDate(LocalDateTime.of(2025, 1, 1, 12, 0))
+                .build();
+    }
+
+    // =========================================================
+    // WeightCalculator — 경계값 비교 (단순 BigDecimal compare)
+    // =========================================================
+
+    @Benchmark
+    public String weightCalc_small() {
+        return weightCalculator.determineWeightGrade(new BigDecimal("0.5"));
+    }
+
+    @Benchmark
+    public String weightCalc_medium() {
+        return weightCalculator.determineWeightGrade(new BigDecimal("7.5"));
+    }
+
+    @Benchmark
+    public String weightCalc_large() {
+        return weightCalculator.determineWeightGrade(new BigDecimal("15"));
+    }
+
+    // =========================================================
+    // CarbonGrade.fromCarbon() — enum 선형 탐색
+    // =========================================================
+
+    @Benchmark
+    public CarbonGrade carbonGrade_grade1() {
+        // 탐색 첫 번째에서 바로 매칭 (최선)
+        return CarbonGrade.fromCarbon(new BigDecimal("0.25"));
+    }
+
+    @Benchmark
+    public CarbonGrade carbonGrade_grade10() {
+        // 탐색 마지막에서 매칭 (최악)
+        return CarbonGrade.fromCarbon(new BigDecimal("60"));
+    }
+
+    // =========================================================
+    // CarbonCalculator — 무게 switch + BigDecimal 곱셈
+    // =========================================================
+
+    @Benchmark
+    public BigDecimal carbonCalc_smallNear() {
+        return carbonCalculator.calculate(dtoSmallNear);
+    }
+
+    @Benchmark
+    public BigDecimal carbonCalc_largeIsland() {
+        return carbonCalculator.calculate(dtoLargeIsland);
+    }
+
+    // =========================================================
+    // FeeCalculator — 단순 20% 곱셈
+    // =========================================================
+
+    @Benchmark
+    public BigDecimal feeCalc_small() {
+        return feeCalculator.calculate(dtoSmallNear);
+    }
+
+    @Benchmark
+    public BigDecimal feeCalc_large() {
+        return feeCalculator.calculate(dtoLargeIsland);
+    }
+
+    @Benchmark
+    public BigDecimal feeCalc_typical() {
+        return feeCalculator.calculate(dtoTypical);
+    }
+
+    // =========================================================
+    // DonationCalculator — 전체 체인 (fee + carbon + grade + 기부금)
+    // =========================================================
+
+    @Benchmark
+    public BigDecimal donationCalc_smallNear() {
+        // GRADE_1 → fee × 5% (기부율 최저)
+        return donationCalculator.calculate(dtoSmallNear);
+    }
+
+    @Benchmark
+    public BigDecimal donationCalc_largeIsland() {
+        // GRADE_10 → fee × 50% (기부율 최고)
+        return donationCalculator.calculate(dtoLargeIsland);
+    }
+
+    @Benchmark
+    public BigDecimal donationCalc_typical() {
+        // GRADE_5~6 범위 (일반 케이스)
+        return donationCalculator.calculate(dtoTypical);
+    }
+
+    // =========================================================
+    // 풀 파이프라인 — 실제 주문 처리 전체 흐름 시뮬레이션
+    // (weightGrade 결정 → carbon 계산 → fee 계산 → donation 계산)
+    // =========================================================
+
+    @Benchmark
+    public BigDecimal fullPipeline_typical() {
+        // 1. 무게로 등급 결정
+        String weightGrade = weightCalculator.determineWeightGrade(new BigDecimal("7.5"));
+
+        // 2. 계산용 DTO 생성
+        PayoutCandidateCreateDto dto = PayoutCandidateCreateDto.builder()
+                .orderPrice(new BigDecimal("50000"))
+                .weightGrade(weightGrade)
+                .deliveryDistance(new BigDecimal("200"))
+                .paymentDate(LocalDateTime.of(2025, 1, 1, 12, 0))
+                .build();
+
+        // 3. 수수료 + 기부금 계산
+        feeCalculator.calculate(dto);
+        return donationCalculator.calculate(dto);
+    }
+}

--- a/payout/src/jmh/java/com/mossy/benchmark/RefundRatioBenchmark.java
+++ b/payout/src/jmh/java/com/mossy/benchmark/RefundRatioBenchmark.java
@@ -1,0 +1,98 @@
+package com.mossy.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * [JMH Benchmark] 환불 비율 배분 알고리즘 성능 벤치마크
+ *
+ * PayoutRefundUseCase.refundCandidates() 내부의 핵심 로직:
+ * 후보 아이템 N건에 환불 금액을 비율로 배분 + 잔여금 보정
+ *
+ * 실제 운영에서 하나의 주문에 후보가 3~5건이므로
+ * 아이템 수(1, 3, 5, 10, 50)별로 처리 시간 차이를 측정
+ */
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class RefundRatioBenchmark {
+
+    // @Param으로 후보 아이템 수를 파라미터화하여 N별 성능 비교
+    @Param({"1", "3", "5", "10", "50"})
+    private int candidateCount;
+
+    private List<BigDecimal> amounts;
+    private BigDecimal refundAmount;
+    private BigDecimal totalAmount;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        // 후보 아이템 금액 리스트 구성
+        // 실제와 유사하게: 대금 6, 수수료 2, 기부금 1, 나머지 1 비율
+        amounts = new ArrayList<>();
+        for (int i = 0; i < candidateCount; i++) {
+            // 아이템마다 다른 금액 부여 (1000 ~ 1000+i*100)
+            amounts.add(new BigDecimal(1000 + i * 100));
+        }
+
+        totalAmount = amounts.stream()
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // 전체 금액의 절반 환불
+        refundAmount = totalAmount.divide(BigDecimal.TWO, 0, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 핵심 비율 배분 알고리즘 벤치마크
+     * PayoutRefundUseCase.refundCandidates()와 동일한 로직
+     */
+    @Benchmark
+    public List<BigDecimal> refundAllocation() {
+        List<BigDecimal> allocatedAmounts = new ArrayList<>();
+        BigDecimal allocatedSum = BigDecimal.ZERO;
+
+        // 1단계: 각 아이템에 비율 × 환불금액 (내림 처리)
+        for (BigDecimal amount : amounts) {
+            BigDecimal ratio = amount.divide(totalAmount, 12, RoundingMode.HALF_UP);
+            BigDecimal itemRefund = refundAmount.multiply(ratio).setScale(0, RoundingMode.DOWN);
+            allocatedAmounts.add(itemRefund);
+            allocatedSum = allocatedSum.add(itemRefund);
+        }
+
+        // 2단계: 잔여금 보정 — 마지막 아이템에 합산
+        BigDecimal remainder = refundAmount.subtract(allocatedSum);
+        if (!allocatedAmounts.isEmpty() && remainder.compareTo(BigDecimal.ZERO) != 0) {
+            int last = allocatedAmounts.size() - 1;
+            allocatedAmounts.set(last, allocatedAmounts.get(last).add(remainder));
+        }
+
+        return allocatedAmounts;
+    }
+
+    /**
+     * totalAmount 계산만 단독 측정
+     * stream().reduce() 비용 파악
+     */
+    @Benchmark
+    public BigDecimal totalAmountCalculation() {
+        return amounts.stream()
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * 비율 계산만 단독 측정 (divide + multiply)
+     */
+    @Benchmark
+    public BigDecimal singleRatioCalculation() {
+        BigDecimal ratio = amounts.get(0).divide(totalAmount, 12, RoundingMode.HALF_UP);
+        return refundAmount.multiply(ratio).setScale(0, RoundingMode.DOWN);
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/app/common/PayoutRefundUseCaseTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/app/common/PayoutRefundUseCaseTest.java
@@ -5,7 +5,7 @@ import com.mossy.boundedContext.payout.domain.payout.PayoutItem;
 import com.mossy.boundedContext.payout.out.repository.PayoutCandidateItemRepository;
 import com.mossy.exception.DomainException;
 import com.mossy.exception.ErrorCode;
-import com.mossy.shared.payout.enums.PayoutEventType;
+import com.mossy.shared.cash.enums.SellerEventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,7 +52,7 @@ class PayoutRefundUseCaseTest {
     @DisplayName("정산이 이미 완료된 후보가 있으면 REFUND_NOT_ALLOWED_AFTER_PAYOUT_COMPLETED")
     void processRefund_already_settled_candidate_throws_exception() {
         PayoutCandidateItem settledCandidate = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, mock(PayoutItem.class)
+                SellerEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, mock(PayoutItem.class)
         );
 
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
@@ -69,7 +69,7 @@ class PayoutRefundUseCaseTest {
     @DisplayName("단건 전액 환불: save 1회 호출, 음수 금액으로 createRefundItem 호출")
     void processRefund_single_candidate_full_refund() {
         PayoutCandidateItem candidate = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), new BigDecimal("0.5"), null
+                SellerEventType.정산__상품판매_대금, new BigDecimal("1000"), new BigDecimal("0.5"), null
         );
 
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
@@ -82,7 +82,7 @@ class PayoutRefundUseCaseTest {
         // 환불 아이템 생성 시 refundAmount가 음수(-1000)로 전달되어야 함
         verify(payoutMapper).createRefundItem(
                 eq(candidate),
-                eq(PayoutEventType.정산__상품환불_대금),
+                eq(SellerEventType.정산__상품환불_대금),
                 eq(new BigDecimal("-1000")),
                 any()
         );
@@ -95,10 +95,10 @@ class PayoutRefundUseCaseTest {
     @DisplayName("2개 후보(600:400) 환불 1000 → 각각 -600, -400으로 생성")
     void processRefund_two_candidates_proportional_allocation() {
         PayoutCandidateItem candidateA = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("600"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_대금, new BigDecimal("600"), BigDecimal.ZERO, null
         );
         PayoutCandidateItem candidateB = mockCandidate(
-                PayoutEventType.정산__상품판매_수수료, new BigDecimal("400"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_수수료, new BigDecimal("400"), BigDecimal.ZERO, null
         );
 
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
@@ -110,12 +110,12 @@ class PayoutRefundUseCaseTest {
 
         // A: 600/1000 × 1000 = 600 → -600
         verify(payoutMapper).createRefundItem(
-                eq(candidateA), eq(PayoutEventType.정산__상품환불_대금),
+                eq(candidateA), eq(SellerEventType.정산__상품환불_대금),
                 eq(new BigDecimal("-600")), any()
         );
         // B: 400/1000 × 1000 = 400 → -400
         verify(payoutMapper).createRefundItem(
-                eq(candidateB), eq(PayoutEventType.정산__상품환불_수수료),
+                eq(candidateB), eq(SellerEventType.정산__상품환불_수수료),
                 eq(new BigDecimal("-400")), any()
         );
     }
@@ -128,9 +128,9 @@ class PayoutRefundUseCaseTest {
         // amount 1:1:1 → total=3, refundAmount=10
         // 각 item → 10 × (1/3) = 3.33... → floor → 3
         // allocatedSum = 9, remainder = 1 → 마지막에 +1 → 4
-        PayoutCandidateItem cA = mockCandidate(PayoutEventType.정산__상품판매_대금, new BigDecimal("1"), BigDecimal.ZERO, null);
-        PayoutCandidateItem cB = mockCandidate(PayoutEventType.정산__상품판매_수수료, new BigDecimal("1"), BigDecimal.ZERO, null);
-        PayoutCandidateItem cC = mockCandidate(PayoutEventType.정산__상품판매_기부금, new BigDecimal("1"), BigDecimal.ZERO, null);
+        PayoutCandidateItem cA = mockCandidate(SellerEventType.정산__상품판매_대금, new BigDecimal("1"), BigDecimal.ZERO, null);
+        PayoutCandidateItem cB = mockCandidate(SellerEventType.정산__상품판매_수수료, new BigDecimal("1"), BigDecimal.ZERO, null);
+        PayoutCandidateItem cC = mockCandidate(SellerEventType.정산__상품판매_기부금, new BigDecimal("1"), BigDecimal.ZERO, null);
 
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
                 .thenReturn(List.of(cA, cB, cC));
@@ -159,7 +159,7 @@ class PayoutRefundUseCaseTest {
     @DisplayName("정산__상품판매_대금 → 정산__상품환불_대금 타입으로 변환")
     void convertToRefundEventType_판매대금_to_환불대금() {
         PayoutCandidateItem candidate = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
         );
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
                 .thenReturn(List.of(candidate));
@@ -168,14 +168,14 @@ class PayoutRefundUseCaseTest {
 
         payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000"));
 
-        verify(payoutMapper).createRefundItem(any(), eq(PayoutEventType.정산__상품환불_대금), any(), any());
+        verify(payoutMapper).createRefundItem(any(), eq(SellerEventType.정산__상품환불_대금), any(), any());
     }
 
     @Test
     @DisplayName("정산__상품판매_수수료 → 정산__상품환불_수수료 타입으로 변환")
     void convertToRefundEventType_판매수수료_to_환불수수료() {
         PayoutCandidateItem candidate = mockCandidate(
-                PayoutEventType.정산__상품판매_수수료, new BigDecimal("200"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_수수료, new BigDecimal("200"), BigDecimal.ZERO, null
         );
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
                 .thenReturn(List.of(candidate));
@@ -184,14 +184,14 @@ class PayoutRefundUseCaseTest {
 
         payoutRefundUseCase.processRefund(1L, new BigDecimal("200"), new BigDecimal("200"));
 
-        verify(payoutMapper).createRefundItem(any(), eq(PayoutEventType.정산__상품환불_수수료), any(), any());
+        verify(payoutMapper).createRefundItem(any(), eq(SellerEventType.정산__상품환불_수수료), any(), any());
     }
 
     @Test
     @DisplayName("정산__상품판매_기부금 → 정산__상품환불_기부금 타입으로 변환")
     void convertToRefundEventType_판매기부금_to_환불기부금() {
         PayoutCandidateItem candidate = mockCandidate(
-                PayoutEventType.정산__상품판매_기부금, new BigDecimal("50"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_기부금, new BigDecimal("50"), BigDecimal.ZERO, null
         );
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
                 .thenReturn(List.of(candidate));
@@ -200,7 +200,7 @@ class PayoutRefundUseCaseTest {
 
         payoutRefundUseCase.processRefund(1L, new BigDecimal("50"), new BigDecimal("50"));
 
-        verify(payoutMapper).createRefundItem(any(), eq(PayoutEventType.정산__상품환불_기부금), any(), any());
+        verify(payoutMapper).createRefundItem(any(), eq(SellerEventType.정산__상품환불_기부금), any(), any());
     }
 
     // ===== 플랫폼 쿠폰 분리 처리 =====
@@ -212,10 +212,10 @@ class PayoutRefundUseCaseTest {
         // refundAmount=500, buyerPaidAmount=1000
         // platform ratio = 500/1000 = 0.5 → platform refund = 200 × 0.5 = 100
         PayoutCandidateItem buyerItem = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
         );
         PayoutCandidateItem platformItem = mockCandidate(
-                PayoutEventType.정산__프로모션_플랫폼부담, new BigDecimal("200"), BigDecimal.ZERO, null
+                SellerEventType.정산__프로모션_플랫폼부담, new BigDecimal("200"), BigDecimal.ZERO, null
         );
 
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
@@ -227,12 +227,12 @@ class PayoutRefundUseCaseTest {
 
         // buyer 항목: -500
         verify(payoutMapper).createRefundItem(
-                eq(buyerItem), eq(PayoutEventType.정산__상품환불_대금),
+                eq(buyerItem), eq(SellerEventType.정산__상품환불_대금),
                 eq(new BigDecimal("-500")), any()
         );
         // platform 항목: -(200 × 0.5) = -100
         verify(payoutMapper).createRefundItem(
-                eq(platformItem), eq(PayoutEventType.정산__상품환불_플랫폼부담),
+                eq(platformItem), eq(SellerEventType.정산__상품환불_플랫폼부담),
                 eq(new BigDecimal("-100")), any()
         );
 
@@ -244,7 +244,7 @@ class PayoutRefundUseCaseTest {
     @DisplayName("플랫폼 쿠폰 항목이 없으면 buyer만 처리하고 save 1회")
     void processRefund_no_platform_coupon_only_buyer_processed() {
         PayoutCandidateItem buyerItem = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
+                SellerEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
         );
 
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
@@ -265,7 +265,7 @@ class PayoutRefundUseCaseTest {
         // amount=1000, carbonKg=1.0, 전액 환불
         // ratio = 1.0 → itemRefundCarbon = 1.0 × 1.0 = 1.00 → negate → -1.00
         PayoutCandidateItem candidate = mockCandidate(
-                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), new BigDecimal("1.00"), null
+                SellerEventType.정산__상품판매_대금, new BigDecimal("1000"), new BigDecimal("1.00"), null
         );
         when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
                 .thenReturn(List.of(candidate));
@@ -287,7 +287,7 @@ class PayoutRefundUseCaseTest {
      * lenient()로 등록하여 UnnecessaryStubbingException을 방지
      */
     private PayoutCandidateItem mockCandidate(
-            PayoutEventType eventType,
+            SellerEventType eventType,
             BigDecimal amount,
             BigDecimal carbonKg,
             PayoutItem payoutItem

--- a/payout/src/test/java/com/mossy/boundedContext/payout/app/common/PayoutRefundUseCaseTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/app/common/PayoutRefundUseCaseTest.java
@@ -1,0 +1,302 @@
+package com.mossy.boundedContext.payout.app.common;
+
+import com.mossy.boundedContext.payout.domain.payout.PayoutCandidateItem;
+import com.mossy.boundedContext.payout.domain.payout.PayoutItem;
+import com.mossy.boundedContext.payout.out.repository.PayoutCandidateItemRepository;
+import com.mossy.exception.DomainException;
+import com.mossy.exception.ErrorCode;
+import com.mossy.shared.payout.enums.PayoutEventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PayoutRefundUseCaseTest {
+
+    @Mock
+    private PayoutCandidateItemRepository candidateItemRepository;
+
+    @Mock
+    private PayoutMapper payoutMapper;
+
+    @InjectMocks
+    private PayoutRefundUseCase payoutRefundUseCase;
+
+    // ===== 예외 케이스 =====
+
+    @Test
+    @DisplayName("orderItemId에 해당하는 정산 후보가 없으면 PAYOUT_CANDIDATE_NOT_FOUND")
+    void processRefund_empty_candidates_throws_exception() {
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000")))
+                .isInstanceOf(DomainException.class)
+                .hasMessageContaining(ErrorCode.PAYOUT_CANDIDATE_NOT_FOUND.getMsg());
+    }
+
+    @Test
+    @DisplayName("정산이 이미 완료된 후보가 있으면 REFUND_NOT_ALLOWED_AFTER_PAYOUT_COMPLETED")
+    void processRefund_already_settled_candidate_throws_exception() {
+        PayoutCandidateItem settledCandidate = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, mock(PayoutItem.class)
+        );
+
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of(settledCandidate));
+
+        assertThatThrownBy(() -> payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000")))
+                .isInstanceOf(DomainException.class)
+                .hasMessageContaining(ErrorCode.REFUND_NOT_ALLOWED_AFTER_PAYOUT_COMPLETED.getMsg());
+    }
+
+    // ===== 단건 전액 환불 =====
+
+    @Test
+    @DisplayName("단건 전액 환불: save 1회 호출, 음수 금액으로 createRefundItem 호출")
+    void processRefund_single_candidate_full_refund() {
+        PayoutCandidateItem candidate = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), new BigDecimal("0.5"), null
+        );
+
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of(candidate));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000"));
+
+        // 환불 아이템 생성 시 refundAmount가 음수(-1000)로 전달되어야 함
+        verify(payoutMapper).createRefundItem(
+                eq(candidate),
+                eq(PayoutEventType.정산__상품환불_대금),
+                eq(new BigDecimal("-1000")),
+                any()
+        );
+        verify(candidateItemRepository, times(1)).save(any());
+    }
+
+    // ===== 비율 배분 =====
+
+    @Test
+    @DisplayName("2개 후보(600:400) 환불 1000 → 각각 -600, -400으로 생성")
+    void processRefund_two_candidates_proportional_allocation() {
+        PayoutCandidateItem candidateA = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("600"), BigDecimal.ZERO, null
+        );
+        PayoutCandidateItem candidateB = mockCandidate(
+                PayoutEventType.정산__상품판매_수수료, new BigDecimal("400"), BigDecimal.ZERO, null
+        );
+
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of(candidateA, candidateB));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000"));
+
+        // A: 600/1000 × 1000 = 600 → -600
+        verify(payoutMapper).createRefundItem(
+                eq(candidateA), eq(PayoutEventType.정산__상품환불_대금),
+                eq(new BigDecimal("-600")), any()
+        );
+        // B: 400/1000 × 1000 = 400 → -400
+        verify(payoutMapper).createRefundItem(
+                eq(candidateB), eq(PayoutEventType.정산__상품환불_수수료),
+                eq(new BigDecimal("-400")), any()
+        );
+    }
+
+    // ===== 잔여금 보정 =====
+
+    @Test
+    @DisplayName("균등 3분할 불가 시 잔여금을 마지막 항목에 보정 (합계 = refundAmount)")
+    void processRefund_remainder_added_to_last_candidate() {
+        // amount 1:1:1 → total=3, refundAmount=10
+        // 각 item → 10 × (1/3) = 3.33... → floor → 3
+        // allocatedSum = 9, remainder = 1 → 마지막에 +1 → 4
+        PayoutCandidateItem cA = mockCandidate(PayoutEventType.정산__상품판매_대금, new BigDecimal("1"), BigDecimal.ZERO, null);
+        PayoutCandidateItem cB = mockCandidate(PayoutEventType.정산__상품판매_수수료, new BigDecimal("1"), BigDecimal.ZERO, null);
+        PayoutCandidateItem cC = mockCandidate(PayoutEventType.정산__상품판매_기부금, new BigDecimal("1"), BigDecimal.ZERO, null);
+
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of(cA, cB, cC));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("10"), new BigDecimal("10"));
+
+        // ArgumentCaptor로 전달된 환불 금액 캡처
+        ArgumentCaptor<BigDecimal> amountCaptor = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(payoutMapper, times(3)).createRefundItem(any(), any(), amountCaptor.capture(), any());
+
+        List<BigDecimal> capturedAmounts = amountCaptor.getAllValues();
+
+        // 세 항목의 환불 금액 합계가 -10이어야 함 (음수)
+        BigDecimal total = capturedAmounts.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(total).isEqualByComparingTo(new BigDecimal("-10"));
+
+        // 마지막 항목이 보정을 받아야 함 (-3, -3이 아닌 -4)
+        assertThat(capturedAmounts.get(2)).isEqualByComparingTo(new BigDecimal("-4"));
+    }
+
+    // ===== 환불 타입 변환 =====
+
+    @Test
+    @DisplayName("정산__상품판매_대금 → 정산__상품환불_대금 타입으로 변환")
+    void convertToRefundEventType_판매대금_to_환불대금() {
+        PayoutCandidateItem candidate = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
+        );
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
+                .thenReturn(List.of(candidate));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000"));
+
+        verify(payoutMapper).createRefundItem(any(), eq(PayoutEventType.정산__상품환불_대금), any(), any());
+    }
+
+    @Test
+    @DisplayName("정산__상품판매_수수료 → 정산__상품환불_수수료 타입으로 변환")
+    void convertToRefundEventType_판매수수료_to_환불수수료() {
+        PayoutCandidateItem candidate = mockCandidate(
+                PayoutEventType.정산__상품판매_수수료, new BigDecimal("200"), BigDecimal.ZERO, null
+        );
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
+                .thenReturn(List.of(candidate));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("200"), new BigDecimal("200"));
+
+        verify(payoutMapper).createRefundItem(any(), eq(PayoutEventType.정산__상품환불_수수료), any(), any());
+    }
+
+    @Test
+    @DisplayName("정산__상품판매_기부금 → 정산__상품환불_기부금 타입으로 변환")
+    void convertToRefundEventType_판매기부금_to_환불기부금() {
+        PayoutCandidateItem candidate = mockCandidate(
+                PayoutEventType.정산__상품판매_기부금, new BigDecimal("50"), BigDecimal.ZERO, null
+        );
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
+                .thenReturn(List.of(candidate));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("50"), new BigDecimal("50"));
+
+        verify(payoutMapper).createRefundItem(any(), eq(PayoutEventType.정산__상품환불_기부금), any(), any());
+    }
+
+    // ===== 플랫폼 쿠폰 분리 처리 =====
+
+    @Test
+    @DisplayName("플랫폼 쿠폰 항목은 buyerPaidAmount 비율로 별도 계산")
+    void processRefund_platform_coupon_refunded_by_ratio() {
+        // buyer: 대금=1000 / platform: 프로모션=200
+        // refundAmount=500, buyerPaidAmount=1000
+        // platform ratio = 500/1000 = 0.5 → platform refund = 200 × 0.5 = 100
+        PayoutCandidateItem buyerItem = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
+        );
+        PayoutCandidateItem platformItem = mockCandidate(
+                PayoutEventType.정산__프로모션_플랫폼부담, new BigDecimal("200"), BigDecimal.ZERO, null
+        );
+
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of(buyerItem, platformItem));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("500"), new BigDecimal("1000"));
+
+        // buyer 항목: -500
+        verify(payoutMapper).createRefundItem(
+                eq(buyerItem), eq(PayoutEventType.정산__상품환불_대금),
+                eq(new BigDecimal("-500")), any()
+        );
+        // platform 항목: -(200 × 0.5) = -100
+        verify(payoutMapper).createRefundItem(
+                eq(platformItem), eq(PayoutEventType.정산__상품환불_플랫폼부담),
+                eq(new BigDecimal("-100")), any()
+        );
+
+        // save는 총 2회 (buyer 1 + platform 1)
+        verify(candidateItemRepository, times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("플랫폼 쿠폰 항목이 없으면 buyer만 처리하고 save 1회")
+    void processRefund_no_platform_coupon_only_buyer_processed() {
+        PayoutCandidateItem buyerItem = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), BigDecimal.ZERO, null
+        );
+
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(1L, "OrderItem"))
+                .thenReturn(List.of(buyerItem));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000"));
+
+        verify(candidateItemRepository, times(1)).save(any());
+    }
+
+    // ===== 탄소 음수 변환 =====
+
+    @Test
+    @DisplayName("환불 탄소량도 비율로 계산 후 음수 전달")
+    void processRefund_carbon_negated_by_ratio() {
+        // amount=1000, carbonKg=1.0, 전액 환불
+        // ratio = 1.0 → itemRefundCarbon = 1.0 × 1.0 = 1.00 → negate → -1.00
+        PayoutCandidateItem candidate = mockCandidate(
+                PayoutEventType.정산__상품판매_대금, new BigDecimal("1000"), new BigDecimal("1.00"), null
+        );
+        when(candidateItemRepository.findByRelIdAndRelTypeCodeWithLock(any(), any()))
+                .thenReturn(List.of(candidate));
+        when(payoutMapper.createRefundItem(any(), any(), any(), any()))
+                .thenReturn(mock(PayoutCandidateItem.class));
+
+        payoutRefundUseCase.processRefund(1L, new BigDecimal("1000"), new BigDecimal("1000"));
+
+        ArgumentCaptor<BigDecimal> carbonCaptor = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(payoutMapper).createRefundItem(any(), any(), any(), carbonCaptor.capture());
+
+        assertThat(carbonCaptor.getValue()).isEqualByComparingTo(new BigDecimal("-1.00"));
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    /**
+     * 헬퍼 메서드에서 생성하는 stub은 테스트 케이스에 따라 일부만 호출될 수 있으므로
+     * lenient()로 등록하여 UnnecessaryStubbingException을 방지
+     */
+    private PayoutCandidateItem mockCandidate(
+            PayoutEventType eventType,
+            BigDecimal amount,
+            BigDecimal carbonKg,
+            PayoutItem payoutItem
+    ) {
+        PayoutCandidateItem candidate = mock(PayoutCandidateItem.class);
+        lenient().when(candidate.getEventType()).thenReturn(eventType);
+        lenient().when(candidate.getAmount()).thenReturn(amount);
+        lenient().when(candidate.getCarbonKg()).thenReturn(carbonKg);
+        lenient().when(candidate.getPayoutItem()).thenReturn(payoutItem);
+        return candidate;
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/CarbonCalculatorTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/CarbonCalculatorTest.java
@@ -1,0 +1,142 @@
+package com.mossy.boundedContext.payout.domain.calculator;
+
+import com.mossy.boundedContext.payout.in.dto.command.PayoutCandidateCreateDto;
+import com.mossy.exception.DomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CarbonCalculatorTest {
+
+    private CarbonCalculator carbonCalculator;
+
+    @BeforeEach
+    void setUp() {
+        carbonCalculator = new CarbonCalculator();
+        // @Value가 주입하는 static 필드를 setter로 직접 설정
+        carbonCalculator.setCarbonCoefficient(new BigDecimal("0.01"));
+    }
+
+    // ===== 예외 케이스 =====
+
+    @Test
+    @DisplayName("null dto → DomainException")
+    void null_dto_throws_exception() {
+        assertThatThrownBy(() -> carbonCalculator.calculate(null))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("null weightGrade → DomainException")
+    void null_weight_grade_throws_exception() {
+        PayoutCandidateCreateDto dto = createDto(null, "30");
+        assertThatThrownBy(() -> carbonCalculator.calculate(dto))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 weightGrade → DomainException")
+    void invalid_weight_grade_throws_exception() {
+        PayoutCandidateCreateDto dto = createDto("초대형", "30");
+        assertThatThrownBy(() -> carbonCalculator.calculate(dto))
+                .isInstanceOf(DomainException.class);
+    }
+
+    // ===== 무게 대표값 검증 (거리 고정: 25km 근거리) =====
+
+    @Test
+    @DisplayName("소형(0.5kg) + 근거리 → 0.5 × 25 × 0.01 = 0.125")
+    void small_weight_near_distance() {
+        PayoutCandidateCreateDto dto = createDto("소형", "25");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("0.125"));
+    }
+
+    @Test
+    @DisplayName("중소형(3kg) + 근거리 → 3 × 25 × 0.01 = 0.75")
+    void medium_small_weight_near_distance() {
+        PayoutCandidateCreateDto dto = createDto("중소형", "25");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("0.75"));
+    }
+
+    @Test
+    @DisplayName("중형(7.5kg) + 근거리 → 7.5 × 25 × 0.01 = 1.875")
+    void medium_weight_near_distance() {
+        PayoutCandidateCreateDto dto = createDto("중형", "25");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("1.875"));
+    }
+
+    @Test
+    @DisplayName("대형(15kg) + 근거리 → 15 × 25 × 0.01 = 3.75")
+    void large_weight_near_distance() {
+        PayoutCandidateCreateDto dto = createDto("대형", "25");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("3.75"));
+    }
+
+    // ===== 거리 구간 경계값 검증 (무게 고정: 소형) =====
+
+    @Test
+    @DisplayName("거리 50km(경계) → 대표값 25km 사용: 0.5 × 25 × 0.01 = 0.125")
+    void distance_50km_boundary_uses_25km_representative() {
+        PayoutCandidateCreateDto dto = createDto("소형", "50");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("0.125"));
+    }
+
+    @Test
+    @DisplayName("거리 51km(경계 초과) → 대표값 100km 사용: 0.5 × 100 × 0.01 = 0.5")
+    void distance_51km_uses_100km_representative() {
+        PayoutCandidateCreateDto dto = createDto("소형", "51");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("0.5"));
+    }
+
+    @Test
+    @DisplayName("거리 150km(경계) → 대표값 100km 사용: 0.5 × 100 × 0.01 = 0.5")
+    void distance_150km_boundary_uses_100km_representative() {
+        PayoutCandidateCreateDto dto = createDto("소형", "150");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("0.5"));
+    }
+
+    @Test
+    @DisplayName("거리 151km(경계 초과) → 대표값 225km 사용: 0.5 × 225 × 0.01 = 1.125")
+    void distance_151km_uses_225km_representative() {
+        PayoutCandidateCreateDto dto = createDto("소형", "151");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("1.125"));
+    }
+
+    @Test
+    @DisplayName("거리 300km(경계) → 대표값 225km 사용: 0.5 × 225 × 0.01 = 1.125")
+    void distance_300km_boundary_uses_225km_representative() {
+        PayoutCandidateCreateDto dto = createDto("소형", "300");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("1.125"));
+    }
+
+    @Test
+    @DisplayName("거리 301km(경계 초과, 도서/제주) → 대표값 400km 사용: 0.5 × 400 × 0.01 = 2.0")
+    void distance_301km_uses_400km_representative() {
+        PayoutCandidateCreateDto dto = createDto("소형", "301");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("2.0"));
+    }
+
+    // ===== 최대 탄소 케이스 =====
+
+    @Test
+    @DisplayName("대형 + 도서/제주 → 15 × 400 × 0.01 = 60")
+    void large_weight_island_distance_max_carbon() {
+        PayoutCandidateCreateDto dto = createDto("대형", "400");
+        assertThat(carbonCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("60"));
+    }
+
+    private PayoutCandidateCreateDto createDto(String weightGrade, String distance) {
+        return PayoutCandidateCreateDto.builder()
+                .weightGrade(weightGrade)
+                .deliveryDistance(new BigDecimal(distance))
+                .orderPrice(new BigDecimal("10000"))
+                .paymentDate(LocalDateTime.now())
+                .build();
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/DistanceCalculatorTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/DistanceCalculatorTest.java
@@ -1,0 +1,86 @@
+package com.mossy.boundedContext.payout.domain.calculator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DistanceCalculatorTest {
+
+    private DistanceCalculator distanceCalculator;
+
+    @BeforeEach
+    void setUp() {
+        distanceCalculator = new DistanceCalculator();
+    }
+
+    @Test
+    @DisplayName("lat1이 null → 기본값 25.0 반환")
+    void null_lat1_returns_default() {
+        BigDecimal result = distanceCalculator.calculateDistance(
+                null, new BigDecimal("126.9"), new BigDecimal("35.1"), new BigDecimal("129.0"));
+        assertThat(result).isEqualByComparingTo(new BigDecimal("25.0"));
+    }
+
+    @Test
+    @DisplayName("lon1이 null → 기본값 25.0 반환")
+    void null_lon1_returns_default() {
+        BigDecimal result = distanceCalculator.calculateDistance(
+                new BigDecimal("37.5"), null, new BigDecimal("35.1"), new BigDecimal("129.0"));
+        assertThat(result).isEqualByComparingTo(new BigDecimal("25.0"));
+    }
+
+    @Test
+    @DisplayName("lat2이 null → 기본값 25.0 반환")
+    void null_lat2_returns_default() {
+        BigDecimal result = distanceCalculator.calculateDistance(
+                new BigDecimal("37.5"), new BigDecimal("126.9"), null, new BigDecimal("129.0"));
+        assertThat(result).isEqualByComparingTo(new BigDecimal("25.0"));
+    }
+
+    @Test
+    @DisplayName("lon2이 null → 기본값 25.0 반환")
+    void null_lon2_returns_default() {
+        BigDecimal result = distanceCalculator.calculateDistance(
+                new BigDecimal("37.5"), new BigDecimal("126.9"), new BigDecimal("35.1"), null);
+        assertThat(result).isEqualByComparingTo(new BigDecimal("25.0"));
+    }
+
+    @Test
+    @DisplayName("모든 파라미터 null → 기본값 25.0 반환")
+    void all_null_returns_default() {
+        BigDecimal result = distanceCalculator.calculateDistance(null, null, null, null);
+        assertThat(result).isEqualByComparingTo(new BigDecimal("25.0"));
+    }
+
+    @Test
+    @DisplayName("동일 좌표 → 0.00km")
+    void same_coordinates_returns_zero() {
+        BigDecimal result = distanceCalculator.calculateDistance(
+                new BigDecimal("37.5"), new BigDecimal("126.9"),
+                new BigDecimal("37.5"), new BigDecimal("126.9"));
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("서울-부산 직선거리 약 300~360km 범위")
+    void seoul_to_busan_distance_in_expected_range() {
+        // 서울: 37.5665, 126.9780 / 부산: 35.1796, 129.0756
+        BigDecimal result = distanceCalculator.calculateDistance(
+                new BigDecimal("37.5665"), new BigDecimal("126.9780"),
+                new BigDecimal("35.1796"), new BigDecimal("129.0756"));
+        assertThat(result).isBetween(new BigDecimal("300"), new BigDecimal("360"));
+    }
+
+    @Test
+    @DisplayName("근거리 좌표 → 소수점 둘째 자리까지 반환")
+    void result_has_two_decimal_places() {
+        BigDecimal result = distanceCalculator.calculateDistance(
+                new BigDecimal("37.5"), new BigDecimal("126.9"),
+                new BigDecimal("37.6"), new BigDecimal("127.0"));
+        assertThat(result.scale()).isEqualTo(2);
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/DonationCalculatorTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/DonationCalculatorTest.java
@@ -1,0 +1,118 @@
+package com.mossy.boundedContext.payout.domain.calculator;
+
+import com.mossy.boundedContext.payout.in.dto.command.PayoutCandidateCreateDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DonationCalculatorTest {
+
+    @Mock
+    private CarbonCalculator carbonCalculator;
+
+    @Mock
+    private FeeCalculator feeCalculator;
+
+    private DonationCalculator donationCalculator;
+
+    @BeforeEach
+    void setUp() {
+        donationCalculator = new DonationCalculator(carbonCalculator, feeCalculator);
+        // @Value가 주입하는 static 필드를 setter로 직접 설정
+        donationCalculator.setMaxDonationRate(new BigDecimal("0.50"));
+    }
+
+    // ===== 탄소 등급별 기부율 검증 =====
+
+    @Test
+    @DisplayName("GRADE_1(탄소 0.25kg): fee×5% < max(fee×50%) → fee×5% 반환")
+    void grade1_donation_is_5_percent_of_fee() {
+        PayoutCandidateCreateDto dto = createDto("10000");
+        when(carbonCalculator.calculate(dto)).thenReturn(new BigDecimal("0.25")); // GRADE_1
+        when(feeCalculator.calculate(dto)).thenReturn(new BigDecimal("2000"));
+
+        // 2000 × 0.05 = 100, max = 2000 × 0.50 = 1000 → min(100, 1000) = 100
+        assertThat(donationCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("100"));
+    }
+
+    @Test
+    @DisplayName("GRADE_4(탄소 3kg): fee×20% < max → fee×20% 반환")
+    void grade4_donation_is_20_percent_of_fee() {
+        PayoutCandidateCreateDto dto = createDto("10000");
+        when(carbonCalculator.calculate(dto)).thenReturn(new BigDecimal("3")); // GRADE_4
+        when(feeCalculator.calculate(dto)).thenReturn(new BigDecimal("2000"));
+
+        // 2000 × 0.20 = 400, max = 1000 → min(400, 1000) = 400
+        assertThat(donationCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("400"));
+    }
+
+    @Test
+    @DisplayName("GRADE_10(탄소 60kg): fee×50% = max(fee×50%) → fee×50% 반환")
+    void grade10_donation_equals_max_limit() {
+        PayoutCandidateCreateDto dto = createDto("10000");
+        when(carbonCalculator.calculate(dto)).thenReturn(new BigDecimal("60")); // GRADE_10
+        when(feeCalculator.calculate(dto)).thenReturn(new BigDecimal("2000"));
+
+        // 2000 × 0.50 = 1000, max = 2000 × 0.50 = 1000 → min(1000, 1000) = 1000
+        assertThat(donationCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("1000"));
+    }
+
+    // ===== 최대 기부금 제한(50%) 검증 =====
+
+    @Test
+    @DisplayName("계산된 기부금이 max(fee×50%)를 초과하면 max로 제한")
+    void donation_capped_at_max_donation_rate() {
+        // maxDonationRate를 낮게 설정하여 cap이 발동되는 케이스 시뮬레이션
+        donationCalculator.setMaxDonationRate(new BigDecimal("0.10")); // max = fee × 10%
+
+        PayoutCandidateCreateDto dto = createDto("10000");
+        when(carbonCalculator.calculate(dto)).thenReturn(new BigDecimal("60")); // GRADE_10 → 50%
+        when(feeCalculator.calculate(dto)).thenReturn(new BigDecimal("2000"));
+
+        // 2000 × 0.50 = 1000, max = 2000 × 0.10 = 200 → min(1000, 200) = 200
+        assertThat(donationCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("200"));
+    }
+
+    // ===== 반올림 검증 (HALF_UP) =====
+
+    @Test
+    @DisplayName("기부금 소수점 HALF_UP 반올림 확인")
+    void donation_rounds_half_up() {
+        PayoutCandidateCreateDto dto = createDto("10000");
+        when(carbonCalculator.calculate(dto)).thenReturn(new BigDecimal("0.25")); // GRADE_1 → 5%
+        when(feeCalculator.calculate(dto)).thenReturn(new BigDecimal("2010"));
+
+        // 2010 × 0.05 = 100.5 → HALF_UP → 101, max = 2010 × 0.50 = 1005 → min(101, 1005) = 101
+        assertThat(donationCalculator.calculate(dto)).isEqualByComparingTo(new BigDecimal("101"));
+    }
+
+    // ===== getGrade, getCarbon 위임 검증 =====
+
+    @Test
+    @DisplayName("getCarbon은 CarbonCalculator에 위임")
+    void get_carbon_delegates_to_carbon_calculator() {
+        PayoutCandidateCreateDto dto = createDto("10000");
+        when(carbonCalculator.calculate(dto)).thenReturn(new BigDecimal("5"));
+
+        assertThat(donationCalculator.getCarbon(dto)).isEqualByComparingTo(new BigDecimal("5"));
+    }
+
+    private PayoutCandidateCreateDto createDto(String price) {
+        return PayoutCandidateCreateDto.builder()
+                .orderPrice(new BigDecimal(price))
+                .weightGrade("소형")
+                .deliveryDistance(new BigDecimal("30"))
+                .paymentDate(LocalDateTime.now())
+                .build();
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/FeeCalculatorTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/FeeCalculatorTest.java
@@ -1,0 +1,107 @@
+package com.mossy.boundedContext.payout.domain.calculator;
+
+import com.mossy.boundedContext.payout.in.dto.command.PayoutCandidateCreateDto;
+import com.mossy.exception.DomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class FeeCalculatorTest {
+
+    private FeeCalculator feeCalculator;
+
+    @BeforeEach
+    void setUp() {
+        // FeeCalculator는 CarbonCalculator를 생성자로 주입받으나,
+        // calculate()는 CarbonCalculator를 사용하지 않으므로 mock으로 대체
+        CarbonCalculator carbonCalculator = mock(CarbonCalculator.class);
+        feeCalculator = new FeeCalculator(carbonCalculator);
+    }
+
+    // ===== 예외 케이스 =====
+
+    @Test
+    @DisplayName("null dto → DomainException")
+    void null_dto_throws_exception() {
+        assertThatThrownBy(() -> feeCalculator.calculate(null))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("orderPrice가 null → DomainException")
+    void null_order_price_throws_exception() {
+        PayoutCandidateCreateDto dto = PayoutCandidateCreateDto.builder()
+                .orderPrice(null)
+                .weightGrade("소형")
+                .deliveryDistance(new BigDecimal("30"))
+                .paymentDate(LocalDateTime.now())
+                .build();
+        assertThatThrownBy(() -> feeCalculator.calculate(dto))
+                .isInstanceOf(DomainException.class);
+    }
+
+    // ===== 수수료 계산 (고정 20%) =====
+
+    @Test
+    @DisplayName("10,000원 → 2,000원 (20%)")
+    void fee_is_20_percent_of_order_price() {
+        assertThat(feeCalculator.calculate(createDto("10000")))
+                .isEqualByComparingTo(new BigDecimal("2000"));
+    }
+
+    @Test
+    @DisplayName("100,000원 → 20,000원")
+    void fee_100000_returns_20000() {
+        assertThat(feeCalculator.calculate(createDto("100000")))
+                .isEqualByComparingTo(new BigDecimal("20000"));
+    }
+
+    @Test
+    @DisplayName("1,000원 → 200원")
+    void fee_1000_returns_200() {
+        assertThat(feeCalculator.calculate(createDto("1000")))
+                .isEqualByComparingTo(new BigDecimal("200"));
+    }
+
+    // ===== 반올림 검증 (HALF_UP) =====
+
+    @Test
+    @DisplayName("10,001원 × 20% = 2,000.2원 → 2,000원 (버림)")
+    void fee_rounds_down_when_decimal_less_than_half() {
+        // 10001 * 0.20 = 2000.2 → HALF_UP → 2000
+        assertThat(feeCalculator.calculate(createDto("10001")))
+                .isEqualByComparingTo(new BigDecimal("2000"));
+    }
+
+    @Test
+    @DisplayName("10,003원 × 20% = 2,000.6원 → 2,001원 (올림)")
+    void fee_rounds_up_when_decimal_half_or_more() {
+        // 10003 * 0.20 = 2000.6 → HALF_UP → 2001
+        assertThat(feeCalculator.calculate(createDto("10003")))
+                .isEqualByComparingTo(new BigDecimal("2001"));
+    }
+
+    @Test
+    @DisplayName("10,005원 × 20% = 2,001.0원 → 2,001원 (정확히 반)")
+    void fee_at_exactly_half_rounds_up() {
+        // 10005 * 0.20 = 2001.0 → HALF_UP → 2001
+        assertThat(feeCalculator.calculate(createDto("10005")))
+                .isEqualByComparingTo(new BigDecimal("2001"));
+    }
+
+    private PayoutCandidateCreateDto createDto(String price) {
+        return PayoutCandidateCreateDto.builder()
+                .orderPrice(new BigDecimal(price))
+                .weightGrade("소형")
+                .deliveryDistance(new BigDecimal("30"))
+                .paymentDate(LocalDateTime.now())
+                .build();
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/WeightCalculatorTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/calculator/WeightCalculatorTest.java
@@ -1,0 +1,102 @@
+package com.mossy.boundedContext.payout.domain.calculator;
+
+import com.mossy.exception.DomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WeightCalculatorTest {
+
+    private WeightCalculator weightCalculator;
+
+    @BeforeEach
+    void setUp() {
+        weightCalculator = new WeightCalculator();
+    }
+
+    @Test
+    @DisplayName("null 무게 → DomainException")
+    void null_weight_throws_exception() {
+        assertThatThrownBy(() -> weightCalculator.determineWeightGrade(null))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("0kg → DomainException")
+    void zero_weight_throws_exception() {
+        assertThatThrownBy(() -> weightCalculator.determineWeightGrade(BigDecimal.ZERO))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("음수 무게 → DomainException")
+    void negative_weight_throws_exception() {
+        assertThatThrownBy(() -> weightCalculator.determineWeightGrade(new BigDecimal("-1")))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("0.5kg → 소형")
+    void weight_0_5kg_returns_small() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("0.5"))).isEqualTo("소형");
+    }
+
+    @Test
+    @DisplayName("1kg → 소형 (경계값)")
+    void weight_1kg_boundary_returns_small() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("1"))).isEqualTo("소형");
+    }
+
+    @Test
+    @DisplayName("1.001kg → 중소형 (소형 경계 초과)")
+    void weight_just_over_1kg_returns_medium_small() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("1.001"))).isEqualTo("중소형");
+    }
+
+    @Test
+    @DisplayName("3kg → 중소형")
+    void weight_3kg_returns_medium_small() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("3"))).isEqualTo("중소형");
+    }
+
+    @Test
+    @DisplayName("5kg → 중소형 (경계값)")
+    void weight_5kg_boundary_returns_medium_small() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("5"))).isEqualTo("중소형");
+    }
+
+    @Test
+    @DisplayName("5.001kg → 중형 (중소형 경계 초과)")
+    void weight_just_over_5kg_returns_medium() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("5.001"))).isEqualTo("중형");
+    }
+
+    @Test
+    @DisplayName("7.5kg → 중형")
+    void weight_7_5kg_returns_medium() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("7.5"))).isEqualTo("중형");
+    }
+
+    @Test
+    @DisplayName("10kg → 중형 (경계값)")
+    void weight_10kg_boundary_returns_medium() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("10"))).isEqualTo("중형");
+    }
+
+    @Test
+    @DisplayName("10.001kg → 대형 (중형 경계 초과)")
+    void weight_just_over_10kg_returns_large() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("10.001"))).isEqualTo("대형");
+    }
+
+    @Test
+    @DisplayName("20kg → 대형")
+    void weight_20kg_returns_large() {
+        assertThat(weightCalculator.determineWeightGrade(new BigDecimal("20"))).isEqualTo("대형");
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutCandidateItemTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutCandidateItemTest.java
@@ -3,7 +3,7 @@ package com.mossy.boundedContext.payout.domain.payout;
 import com.mossy.boundedContext.payout.domain.seller.PayoutSeller;
 import com.mossy.boundedContext.payout.domain.user.PayoutUser;
 import com.mossy.exception.DomainException;
-import com.mossy.shared.payout.enums.PayoutEventType;
+import com.mossy.shared.cash.enums.SellerEventType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +46,7 @@ class PayoutCandidateItemTest {
     @DisplayName("relTypeCode가 null → DomainException")
     void null_rel_type_code_throws_exception() {
         assertThatThrownBy(() -> PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode(null)
                 .relId(1L)
                 .paymentDate(LocalDateTime.now())
@@ -60,7 +60,7 @@ class PayoutCandidateItemTest {
     @DisplayName("relTypeCode가 공백 → DomainException")
     void blank_rel_type_code_throws_exception() {
         assertThatThrownBy(() -> PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("   ")
                 .relId(1L)
                 .paymentDate(LocalDateTime.now())
@@ -74,7 +74,7 @@ class PayoutCandidateItemTest {
     @DisplayName("relId가 null → DomainException")
     void null_rel_id_throws_exception() {
         assertThatThrownBy(() -> PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("ORDER_ITEM")
                 .relId(null)
                 .paymentDate(LocalDateTime.now())
@@ -88,7 +88,7 @@ class PayoutCandidateItemTest {
     @DisplayName("paymentDate가 null → DomainException")
     void null_payment_date_throws_exception() {
         assertThatThrownBy(() -> PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("ORDER_ITEM")
                 .relId(1L)
                 .paymentDate(null)
@@ -102,7 +102,7 @@ class PayoutCandidateItemTest {
     @DisplayName("payee가 null → DomainException")
     void null_payee_throws_exception() {
         assertThatThrownBy(() -> PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("ORDER_ITEM")
                 .relId(1L)
                 .paymentDate(LocalDateTime.now())
@@ -118,7 +118,7 @@ class PayoutCandidateItemTest {
     @DisplayName("amount가 null이면 BigDecimal.ZERO로 기본값 설정")
     void null_amount_defaults_to_zero() {
         PayoutCandidateItem item = PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("ORDER_ITEM")
                 .relId(1L)
                 .paymentDate(LocalDateTime.now())
@@ -137,7 +137,7 @@ class PayoutCandidateItemTest {
         LocalDateTime paymentDate = LocalDateTime.of(2025, 1, 1, 12, 0);
 
         PayoutCandidateItem item = PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("ORDER_ITEM")
                 .relId(1L)
                 .paymentDate(paymentDate)
@@ -149,7 +149,7 @@ class PayoutCandidateItemTest {
                 .carbonKg(new BigDecimal("0.125"))
                 .build();
 
-        assertThat(item.getEventType()).isEqualTo(PayoutEventType.정산__상품판매_대금);
+        assertThat(item.getEventType()).isEqualTo(SellerEventType.정산__상품판매_대금);
         assertThat(item.getRelTypeCode()).isEqualTo("ORDER_ITEM");
         assertThat(item.getRelId()).isEqualTo(1L);
         assertThat(item.getPaymentDate()).isEqualTo(paymentDate);
@@ -165,7 +165,7 @@ class PayoutCandidateItemTest {
     @DisplayName("초기에 payoutItem은 null (미처리 상태)")
     void initial_payout_item_is_null() {
         PayoutCandidateItem item = PayoutCandidateItem.builder()
-                .eventType(PayoutEventType.정산__상품판매_대금)
+                .eventType(SellerEventType.정산__상품판매_대금)
                 .relTypeCode("ORDER_ITEM")
                 .relId(1L)
                 .paymentDate(LocalDateTime.now())

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutCandidateItemTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutCandidateItemTest.java
@@ -1,0 +1,178 @@
+package com.mossy.boundedContext.payout.domain.payout;
+
+import com.mossy.boundedContext.payout.domain.seller.PayoutSeller;
+import com.mossy.boundedContext.payout.domain.user.PayoutUser;
+import com.mossy.exception.DomainException;
+import com.mossy.shared.payout.enums.PayoutEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class PayoutCandidateItemTest {
+
+    private PayoutSeller payee;
+    private PayoutUser payer;
+
+    @BeforeEach
+    void setUp() {
+        payee = mock(PayoutSeller.class);
+        payer = mock(PayoutUser.class);
+    }
+
+    // ===== 필수 필드 검증 =====
+
+    @Test
+    @DisplayName("eventType이 null → DomainException")
+    void null_event_type_throws_exception() {
+        assertThatThrownBy(() -> PayoutCandidateItem.builder()
+                .eventType(null)
+                .relTypeCode("ORDER_ITEM")
+                .relId(1L)
+                .paymentDate(LocalDateTime.now())
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .build())
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("relTypeCode가 null → DomainException")
+    void null_rel_type_code_throws_exception() {
+        assertThatThrownBy(() -> PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode(null)
+                .relId(1L)
+                .paymentDate(LocalDateTime.now())
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .build())
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("relTypeCode가 공백 → DomainException")
+    void blank_rel_type_code_throws_exception() {
+        assertThatThrownBy(() -> PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("   ")
+                .relId(1L)
+                .paymentDate(LocalDateTime.now())
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .build())
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("relId가 null → DomainException")
+    void null_rel_id_throws_exception() {
+        assertThatThrownBy(() -> PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("ORDER_ITEM")
+                .relId(null)
+                .paymentDate(LocalDateTime.now())
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .build())
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("paymentDate가 null → DomainException")
+    void null_payment_date_throws_exception() {
+        assertThatThrownBy(() -> PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("ORDER_ITEM")
+                .relId(1L)
+                .paymentDate(null)
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .build())
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("payee가 null → DomainException")
+    void null_payee_throws_exception() {
+        assertThatThrownBy(() -> PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("ORDER_ITEM")
+                .relId(1L)
+                .paymentDate(LocalDateTime.now())
+                .payee(null)
+                .amount(new BigDecimal("1000"))
+                .build())
+                .isInstanceOf(DomainException.class);
+    }
+
+    // ===== amount 기본값 검증 =====
+
+    @Test
+    @DisplayName("amount가 null이면 BigDecimal.ZERO로 기본값 설정")
+    void null_amount_defaults_to_zero() {
+        PayoutCandidateItem item = PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("ORDER_ITEM")
+                .relId(1L)
+                .paymentDate(LocalDateTime.now())
+                .payee(payee)
+                .amount(null)
+                .build();
+
+        assertThat(item.getAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    // ===== 정상 생성 검증 =====
+
+    @Test
+    @DisplayName("모든 필드 정상 입력 시 객체 생성 및 필드 검증")
+    void valid_item_creation() {
+        LocalDateTime paymentDate = LocalDateTime.of(2025, 1, 1, 12, 0);
+
+        PayoutCandidateItem item = PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("ORDER_ITEM")
+                .relId(1L)
+                .paymentDate(paymentDate)
+                .payer(payer)
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .weightGrade("소형")
+                .deliveryDistance(new BigDecimal("30"))
+                .carbonKg(new BigDecimal("0.125"))
+                .build();
+
+        assertThat(item.getEventType()).isEqualTo(PayoutEventType.정산__상품판매_대금);
+        assertThat(item.getRelTypeCode()).isEqualTo("ORDER_ITEM");
+        assertThat(item.getRelId()).isEqualTo(1L);
+        assertThat(item.getPaymentDate()).isEqualTo(paymentDate);
+        assertThat(item.getPayer()).isEqualTo(payer);
+        assertThat(item.getPayee()).isEqualTo(payee);
+        assertThat(item.getAmount()).isEqualByComparingTo(new BigDecimal("1000"));
+        assertThat(item.getWeightGrade()).isEqualTo("소형");
+        assertThat(item.getDeliveryDistance()).isEqualByComparingTo(new BigDecimal("30"));
+        assertThat(item.getCarbonKg()).isEqualByComparingTo(new BigDecimal("0.125"));
+    }
+
+    @Test
+    @DisplayName("초기에 payoutItem은 null (미처리 상태)")
+    void initial_payout_item_is_null() {
+        PayoutCandidateItem item = PayoutCandidateItem.builder()
+                .eventType(PayoutEventType.정산__상품판매_대금)
+                .relTypeCode("ORDER_ITEM")
+                .relId(1L)
+                .paymentDate(LocalDateTime.now())
+                .payee(payee)
+                .amount(new BigDecimal("1000"))
+                .build();
+
+        assertThat(item.getPayoutItem()).isNull();
+    }
+}

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutTest.java
@@ -5,7 +5,7 @@ import com.mossy.boundedContext.payout.domain.user.PayoutUser;
 import com.mossy.exception.DomainException;
 import com.mossy.global.config.GlobalConfig;
 import com.mossy.global.eventPublisher.EventPublisher;
-import com.mossy.shared.payout.enums.PayoutEventType;
+import com.mossy.shared.cash.enums.SellerEventType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,9 +71,9 @@ class PayoutTest {
     @DisplayName("addItem 정상 호출 시 amount 누적")
     void addItem_accumulates_amount() {
         Payout payout = new Payout(payee);
-        payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
+        payout.addItem(SellerEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
                 LocalDateTime.now(), payer, payee, new BigDecimal("1000"));
-        payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 2L,
+        payout.addItem(SellerEventType.정산__상품판매_대금, "ORDER_ITEM", 2L,
                 LocalDateTime.now(), payer, payee, new BigDecimal("2000"));
 
         assertThat(payout.getAmount()).isEqualByComparingTo(new BigDecimal("3000"));
@@ -83,7 +83,7 @@ class PayoutTest {
     @DisplayName("addItem 후 items 리스트 크기 증가")
     void addItem_increases_items_size() {
         Payout payout = new Payout(payee);
-        payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
+        payout.addItem(SellerEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
                 LocalDateTime.now(), payer, payee, new BigDecimal("1000"));
 
         assertThat(payout.getItems()).hasSize(1);
@@ -97,7 +97,7 @@ class PayoutTest {
         payout.completePayout();
 
         assertThatThrownBy(() ->
-                payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
+                payout.addItem(SellerEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
                         LocalDateTime.now(), payer, payee, new BigDecimal("1000")))
                 .isInstanceOf(DomainException.class);
     }

--- a/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/domain/payout/PayoutTest.java
@@ -1,0 +1,183 @@
+package com.mossy.boundedContext.payout.domain.payout;
+
+import com.mossy.boundedContext.payout.domain.seller.PayoutSeller;
+import com.mossy.boundedContext.payout.domain.user.PayoutUser;
+import com.mossy.exception.DomainException;
+import com.mossy.global.config.GlobalConfig;
+import com.mossy.global.eventPublisher.EventPublisher;
+import com.mossy.shared.payout.enums.PayoutEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PayoutTest {
+
+    private PayoutSeller payee;
+    private PayoutUser payer;
+
+    @BeforeEach
+    void setUp() {
+        payee = mock(PayoutSeller.class);
+        payer = mock(PayoutUser.class);
+
+        // completePayout()에서 publishEvent() → GlobalConfig.getEventPublisher().publish()를 호출하므로
+        // static 필드에 mock EventPublisher를 주입해 NPE를 방지
+        EventPublisher mockPublisher = mock(EventPublisher.class);
+        ReflectionTestUtils.setField(GlobalConfig.class, "eventPublisher", mockPublisher);
+    }
+
+    // ===== 생성 검증 =====
+
+    @Test
+    @DisplayName("payee가 null이면 DomainException 발생")
+    void constructor_with_null_payee_throws_exception() {
+        assertThatThrownBy(() -> new Payout(null))
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("생성 직후 amount는 0")
+    void initial_amount_is_zero() {
+        Payout payout = new Payout(payee);
+        assertThat(payout.getAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("생성 직후 isCompleted = false")
+    void initial_is_not_completed() {
+        Payout payout = new Payout(payee);
+        assertThat(payout.isCompleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("생성 직후 isCredited = false")
+    void initial_is_not_credited() {
+        Payout payout = new Payout(payee);
+        assertThat(payout.isCredited()).isFalse();
+    }
+
+    // ===== addItem 검증 =====
+
+    @Test
+    @DisplayName("addItem 정상 호출 시 amount 누적")
+    void addItem_accumulates_amount() {
+        Payout payout = new Payout(payee);
+        payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
+                LocalDateTime.now(), payer, payee, new BigDecimal("1000"));
+        payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 2L,
+                LocalDateTime.now(), payer, payee, new BigDecimal("2000"));
+
+        assertThat(payout.getAmount()).isEqualByComparingTo(new BigDecimal("3000"));
+    }
+
+    @Test
+    @DisplayName("addItem 후 items 리스트 크기 증가")
+    void addItem_increases_items_size() {
+        Payout payout = new Payout(payee);
+        payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
+                LocalDateTime.now(), payer, payee, new BigDecimal("1000"));
+
+        assertThat(payout.getItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("이미 완료된 Payout에 addItem → DomainException")
+    void addItem_on_completed_payout_throws_exception() {
+        Payout payout = new Payout(payee);
+        stubPayeeForCompleting();
+        payout.completePayout();
+
+        assertThatThrownBy(() ->
+                payout.addItem(PayoutEventType.정산__상품판매_대금, "ORDER_ITEM", 1L,
+                        LocalDateTime.now(), payer, payee, new BigDecimal("1000")))
+                .isInstanceOf(DomainException.class);
+    }
+
+    // ===== completePayout 검증 =====
+
+    @Test
+    @DisplayName("completePayout 정상 호출 후 isCompleted = true")
+    void completePayout_sets_completed_true() {
+        Payout payout = new Payout(payee);
+        stubPayeeForCompleting();
+
+        payout.completePayout();
+
+        assertThat(payout.isCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("completePayout 호출 후 payoutDate가 설정됨")
+    void completePayout_sets_payout_date() {
+        Payout payout = new Payout(payee);
+        stubPayeeForCompleting();
+
+        payout.completePayout();
+
+        assertThat(payout.isCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 완료된 Payout에 completePayout 재호출 → DomainException")
+    void completePayout_on_already_completed_throws_exception() {
+        Payout payout = new Payout(payee);
+        stubPayeeForCompleting();
+        payout.completePayout();
+
+        assertThatThrownBy(payout::completePayout)
+                .isInstanceOf(DomainException.class);
+    }
+
+    // ===== creditToWallet 검증 =====
+
+    @Test
+    @DisplayName("완료되지 않은 Payout에 creditToWallet → DomainException")
+    void creditToWallet_on_not_completed_throws_exception() {
+        Payout payout = new Payout(payee);
+
+        assertThatThrownBy(payout::creditToWallet)
+                .isInstanceOf(DomainException.class);
+    }
+
+    @Test
+    @DisplayName("creditToWallet 정상 호출 후 isCredited = true")
+    void creditToWallet_sets_credited_true() {
+        Payout payout = new Payout(payee);
+        stubPayeeForCompleting();
+        payout.completePayout();
+
+        payout.creditToWallet();
+
+        assertThat(payout.isCredited()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 credit된 Payout에 creditToWallet 재호출 → DomainException")
+    void creditToWallet_on_already_credited_throws_exception() {
+        Payout payout = new Payout(payee);
+        stubPayeeForCompleting();
+        payout.completePayout();
+        payout.creditToWallet();
+
+        assertThatThrownBy(payout::creditToWallet)
+                .isInstanceOf(DomainException.class);
+    }
+
+    /**
+     * completePayout() 내부의 toDto() 호출 시 payee 필드가 필요하므로 미리 stub 설정
+     */
+    private void stubPayeeForCompleting() {
+        when(payee.getId()).thenReturn(1L);
+        when(payee.getStoreName()).thenReturn("테스트 스토어");
+        when(payee.isSystem()).thenReturn(false);
+    }
+}

--- a/payout/src/test/java/com/mossy/shared/payout/enums/CarbonGradeTest.java
+++ b/payout/src/test/java/com/mossy/shared/payout/enums/CarbonGradeTest.java
@@ -1,0 +1,71 @@
+package com.mossy.shared.payout.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CarbonGradeTest {
+
+    @Test
+    @DisplayName("0kg → GRADE_1")
+    void carbon_0kg_returns_grade1() {
+        assertThat(CarbonGrade.fromCarbon(new BigDecimal("0"))).isEqualTo(CarbonGrade.GRADE_1);
+    }
+
+    @Test
+    @DisplayName("0.25kg → GRADE_1 (범위 내)")
+    void carbon_0_25kg_returns_grade1() {
+        assertThat(CarbonGrade.fromCarbon(new BigDecimal("0.25"))).isEqualTo(CarbonGrade.GRADE_1);
+    }
+
+    @ParameterizedTest(name = "{0}kg → {1}")
+    @CsvSource({
+            "0.5, GRADE_2",
+            "1,   GRADE_3",
+            "2,   GRADE_4",
+            "5,   GRADE_5",
+            "10,  GRADE_6",
+            "15,  GRADE_7",
+            "25,  GRADE_8",
+            "40,  GRADE_9",
+            "60,  GRADE_10"
+    })
+    @DisplayName("각 등급 하한 경계값 테스트")
+    void boundary_lower_values(String carbon, String expectedGrade) {
+        CarbonGrade result = CarbonGrade.fromCarbon(new BigDecimal(carbon.trim()));
+        assertThat(result).isEqualTo(CarbonGrade.valueOf(expectedGrade.trim()));
+    }
+
+    @Test
+    @DisplayName("매우 큰 탄소량 → GRADE_10")
+    void very_large_carbon_returns_grade10() {
+        assertThat(CarbonGrade.fromCarbon(new BigDecimal("9999"))).isEqualTo(CarbonGrade.GRADE_10);
+    }
+
+    @Test
+    @DisplayName("GRADE_1 기부율 5%")
+    void grade1_donation_rate_is_5_percent() {
+        assertThat(CarbonGrade.GRADE_1.getDonationRate()).isEqualByComparingTo(new BigDecimal("0.05"));
+    }
+
+    @Test
+    @DisplayName("GRADE_10 기부율 50%")
+    void grade10_donation_rate_is_50_percent() {
+        assertThat(CarbonGrade.GRADE_10.getDonationRate()).isEqualByComparingTo(new BigDecimal("0.50"));
+    }
+
+    @Test
+    @DisplayName("등급이 높을수록 기부율도 높음 (단조증가)")
+    void higher_grade_has_higher_donation_rate() {
+        CarbonGrade[] grades = CarbonGrade.values();
+        for (int i = 0; i < grades.length - 1; i++) {
+            assertThat(grades[i].getDonationRate())
+                    .isLessThan(grades[i + 1].getDonationRate());
+        }
+    }
+}


### PR DESCRIPTION
## 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #202 

## ✨️ 작업 내용
테스트 코드 (payout 모듈 단위 테스트)                                                                                                                                     

  도메인 계층
  - PayoutTest (13개) - Payout 생성/addItem/completePayout/creditToWallet 상태 전이 및 예외 검증
  - PayoutCandidateItemTest (9개) - 필드 유효성 검증, 기본값, 초기 상태 검증

  Calculator 계층
  - FeeCalculatorTest (8개) - 수수료 20% 계산, 소수점 처리(버림/올림/반올림)
  - WeightCalculatorTest (10개+) - 무게 등급 경계값 테스트 (소형/중소형/중형/대형)
  - DistanceCalculatorTest (8개) - null 입력 기본값 처리, 서울-부산 거리 등
  - CarbonCalculatorTest (13개) - 무게등급 × 거리구간 조합 탄소량 계산
  - DonationCalculatorTest (6개) - 등급별 기부율, max 한도(fee×50%) 검증

  Enum 테스트
  - CarbonGradeTest (7개) - 등급 경계값, 기부율 단조증가 검증

  UseCase 테스트 (Mock)
  - PayoutRefundUseCaseTest (11개) - 환불 비율 배분, 플랫폼 쿠폰 분리, 타입 변환, 탄소량 비율 계산

  벤치마크 (JMH)
  - CalculatorBenchmark (14개) - 각 Calculator 성능 측정
  - RefundRatioBenchmark (3개) - 환불 비율 계산 알고리즘 성능 비교

## 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

## 📸 구현 결과 (?)
<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
