### PR TITLE
[Feature] #214 : 정산 주기 변경 및 정산 조회 API 생성

### DIFF
--- a/elasticsearch/compose-es.yml
+++ b/elasticsearch/compose-es.yml
@@ -32,7 +32,3 @@ services:
 volumes:
   es_data:
     driver: local
-
-networks:
-  mossy-network:
-    external: true

--- a/payout/src/main/java/com/mossy/boundedContext/payout/app/common/PayoutQueryUseCase.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/app/common/PayoutQueryUseCase.java
@@ -1,0 +1,70 @@
+package com.mossy.boundedContext.payout.app.common;
+
+import com.mossy.boundedContext.payout.domain.payout.Payout;
+import com.mossy.boundedContext.payout.domain.seller.PayoutSeller;
+import com.mossy.boundedContext.payout.in.dto.response.PayoutListResponseDto;
+import com.mossy.boundedContext.payout.in.dto.response.PayoutResponseDto;
+import com.mossy.boundedContext.payout.out.repository.PayoutRepository;
+import com.mossy.boundedContext.payout.out.repository.PayoutSellerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PayoutQueryUseCase {
+
+    private final PayoutSellerRepository payoutSellerRepository;
+    private final PayoutRepository payoutRepository;
+
+    public PayoutListResponseDto findMonthlyPayouts(Long userId, int year, int month) {
+        Optional<PayoutSeller> sellerOpt = payoutSellerRepository.findByUserId(userId);
+
+        if (sellerOpt.isEmpty()) {
+            return emptyResult();
+        }
+
+        PayoutSeller seller = sellerOpt.get();
+        LocalDateTime from = LocalDate.of(year, month, 1).atStartOfDay();
+        LocalDateTime to = from.plusMonths(1);
+
+        List<Payout> payouts = payoutRepository
+                .findByPayeeAndPayoutDateBetweenOrderByPayoutDateDesc(seller, from, to);
+
+        BigDecimal totalAmount = payouts.stream()
+                .map(Payout::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal creditedAmount = payouts.stream()
+                .filter(Payout::isCredited)
+                .map(Payout::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal pendingCreditAmount = totalAmount.subtract(creditedAmount);
+
+        PayoutListResponseDto.Summary summary = new PayoutListResponseDto.Summary(
+                totalAmount, creditedAmount, pendingCreditAmount
+        );
+
+        List<PayoutResponseDto> payoutDtos = payouts.stream()
+                .map(PayoutResponseDto::from)
+                .toList();
+
+        return new PayoutListResponseDto(summary, payoutDtos);
+    }
+
+    private PayoutListResponseDto emptyResult() {
+        PayoutListResponseDto.Summary summary = new PayoutListResponseDto.Summary(
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO
+        );
+        return new PayoutListResponseDto(summary, Collections.emptyList());
+    }
+}

--- a/payout/src/main/java/com/mossy/boundedContext/payout/in/PayoutController.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/in/PayoutController.java
@@ -1,0 +1,39 @@
+package com.mossy.boundedContext.payout.in;
+
+import com.mossy.boundedContext.payout.app.common.PayoutQueryUseCase;
+import com.mossy.boundedContext.payout.in.dto.response.PayoutListResponseDto;
+import com.mossy.exception.SuccessCode;
+import com.mossy.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Tag(name = "Payout", description = "판매자 정산 조회 API")
+@RestController
+@RequestMapping("/api/v1/payouts")
+@RequiredArgsConstructor
+public class PayoutController {
+
+    private final PayoutQueryUseCase payoutQueryUseCase;
+
+    @Operation(summary = "월별 정산 조회", description = "해당 월의 정산 요약 및 목록을 조회합니다. year/month 미입력 시 현재 월로 조회합니다.")
+    @GetMapping
+    public RsData<PayoutListResponseDto> getMonthlyPayouts(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month) {
+
+        int targetYear = (year != null) ? year : LocalDate.now().getYear();
+        int targetMonth = (month != null) ? month : LocalDate.now().getMonthValue();
+
+        PayoutListResponseDto result = payoutQueryUseCase.findMonthlyPayouts(userId, targetYear, targetMonth);
+        return RsData.success(SuccessCode.PAYOUT_LIST_FOUND, result);
+    }
+}

--- a/payout/src/main/java/com/mossy/boundedContext/payout/in/PayoutScheduler.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/in/PayoutScheduler.java
@@ -61,16 +61,28 @@ public class PayoutScheduler {
     }
 
     /**
-     * 일별 지급 배치 - 매일 23:59 실행
+     * 지급 배치 - 매월 15일 23:59 실행
      */
-    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
-    public void runDailyWalletCredit() throws Exception {
+    @Scheduled(cron = "0 59 23 15 * *", zone = "Asia/Seoul")
+    public void runWalletCreditOn15th() throws Exception {
+        runWalletCreditBatchJob();
+    }
+
+    /**
+     * 지급 배치 - 매월 말일 23:59 실행
+     */
+    @Scheduled(cron = "0 59 23 L * *", zone = "Asia/Seoul")
+    public void runWalletCreditOnLastDay() throws Exception {
+        runWalletCreditBatchJob();
+    }
+
+    private void runWalletCreditBatchJob() throws Exception {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString(
                         "runDateTime",
                         LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                 )
                 .toJobParameters();
-        JobExecution execution = jobLauncher.run(payoutDailyWalletCreditJob, jobParameters);
+        jobLauncher.run(payoutDailyWalletCreditJob, jobParameters);
     }
 }

--- a/payout/src/main/java/com/mossy/boundedContext/payout/in/dto/response/PayoutListResponseDto.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/in/dto/response/PayoutListResponseDto.java
@@ -1,0 +1,15 @@
+package com.mossy.boundedContext.payout.in.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record PayoutListResponseDto(
+        Summary summary,
+        List<PayoutResponseDto> payouts
+) {
+    public record Summary(
+            BigDecimal totalAmount,
+            BigDecimal creditedAmount,
+            BigDecimal pendingCreditAmount
+    ) {}
+}

--- a/payout/src/main/java/com/mossy/boundedContext/payout/in/dto/response/PayoutResponseDto.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/in/dto/response/PayoutResponseDto.java
@@ -1,0 +1,29 @@
+package com.mossy.boundedContext.payout.in.dto.response;
+
+import com.mossy.boundedContext.payout.domain.payout.Payout;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PayoutResponseDto {
+    private final Long id;
+    private final String status;
+    private final BigDecimal amount;
+    private final LocalDateTime payoutDate;
+    private final LocalDateTime creditDate;
+
+    public static PayoutResponseDto from(Payout payout) {
+        String status = payout.isCredited() ? "CREDITED" : "COMPLETED";
+        return PayoutResponseDto.builder()
+                .id(payout.getId())
+                .status(status)
+                .amount(payout.getAmount())
+                .payoutDate(payout.getPayoutDate())
+                .creditDate(payout.getCreditDate())
+                .build();
+    }
+}

--- a/payout/src/main/java/com/mossy/boundedContext/payout/out/repository/PayoutRepository.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/out/repository/PayoutRepository.java
@@ -61,6 +61,9 @@ public interface PayoutRepository extends JpaRepository<Payout, Long> {
 
     List<Payout> findByPayoutDateBetween(LocalDateTime startDate, LocalDateTime endDate);
 
+    List<Payout> findByPayeeAndPayoutDateBetweenOrderByPayoutDateDesc(
+            PayoutSeller payee, LocalDateTime from, LocalDateTime to);
+
     /**
      * 정산은 완료되었으나 아직 지급되지 않은 Payout들을 조회
      * 지급 배치에서 사용

--- a/payout/src/main/java/com/mossy/boundedContext/payout/out/repository/PayoutSellerRepository.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/out/repository/PayoutSellerRepository.java
@@ -18,4 +18,6 @@ public interface PayoutSellerRepository extends JpaRepository<PayoutSeller, Long
      * @return 조회된 PayoutSeller 객체 (Optional)
      */
     Optional<PayoutSeller> findByStoreName(String storeName);
+
+    Optional<PayoutSeller> findByUserId(Long userId);
 }

--- a/payout/src/main/java/com/mossy/boundedContext/payout/out/repository/PayoutUserRepository.java
+++ b/payout/src/main/java/com/mossy/boundedContext/payout/out/repository/PayoutUserRepository.java
@@ -1,3 +1,4 @@
+
 package com.mossy.boundedContext.payout.out.repository;
 
 import com.mossy.boundedContext.payout.domain.user.PayoutUser;

--- a/payout/src/main/java/com/mossy/exception/SuccessCode.java
+++ b/payout/src/main/java/com/mossy/exception/SuccessCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessCode implements BaseCode {
     PAYOUT_DAILY_WALLET_NOTHING_TO_PROCESS(200, "처리할 정산이 없습니다."),
     PAYOUT_DAILY_WALLET_CREDIT_PROCESSED(201, "판매자 지급 처리가 완료되었습니다."),
-    DONATION_LOGS_FOUND(200, "기부 내역 조회에 성공했습니다.");
+    DONATION_LOGS_FOUND(200, "기부 내역 조회에 성공했습니다."),
+    PAYOUT_LIST_FOUND(200, "정산 목록 조회에 성공했습니다.");
 
     private final int status;
     private final String msg;

--- a/payout/src/test/java/com/mossy/boundedContext/payout/in/PayoutControllerTest.java
+++ b/payout/src/test/java/com/mossy/boundedContext/payout/in/PayoutControllerTest.java
@@ -1,0 +1,213 @@
+package com.mossy.boundedContext.payout.in;
+
+import com.mossy.boundedContext.payout.app.common.PayoutQueryUseCase;
+import com.mossy.boundedContext.payout.in.dto.response.PayoutListResponseDto;
+import com.mossy.boundedContext.payout.in.dto.response.PayoutResponseDto;
+import com.mossy.exception.SuccessCode;
+import com.mossy.global.rsData.RsData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PayoutControllerTest {
+
+    @Mock
+    private PayoutQueryUseCase payoutQueryUseCase;
+
+    @InjectMocks
+    private PayoutController payoutController;
+
+    // ===== 파라미터 전달 검증 =====
+
+    @Test
+    @DisplayName("year/month 명시 시 UseCase에 해당 값 그대로 전달")
+    void getMonthlyPayouts_explicit_year_month_passed_to_useCase() {
+        Long userId = 1L;
+        int year = 2026;
+        int month = 2;
+        when(payoutQueryUseCase.findMonthlyPayouts(userId, year, month))
+                .thenReturn(emptyResult());
+
+        payoutController.getMonthlyPayouts(userId, year, month);
+
+        verify(payoutQueryUseCase).findMonthlyPayouts(userId, year, month);
+    }
+
+    @Test
+    @DisplayName("year/month null이면 현재 연월을 UseCase에 전달")
+    void getMonthlyPayouts_null_year_month_uses_current_date() {
+        Long userId = 1L;
+        int currentYear = LocalDate.now().getYear();
+        int currentMonth = LocalDate.now().getMonthValue();
+        when(payoutQueryUseCase.findMonthlyPayouts(userId, currentYear, currentMonth))
+                .thenReturn(emptyResult());
+
+        payoutController.getMonthlyPayouts(userId, null, null);
+
+        verify(payoutQueryUseCase).findMonthlyPayouts(userId, currentYear, currentMonth);
+    }
+
+    @Test
+    @DisplayName("year만 입력하고 month null이면 현재 월 사용")
+    void getMonthlyPayouts_year_only_uses_current_month() {
+        Long userId = 1L;
+        int year = 2025;
+        int currentMonth = LocalDate.now().getMonthValue();
+
+        ArgumentCaptor<Integer> monthCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(payoutQueryUseCase.findMonthlyPayouts(eq(userId), eq(year), monthCaptor.capture()))
+                .thenReturn(emptyResult());
+
+        payoutController.getMonthlyPayouts(userId, year, null);
+
+        assertThat(monthCaptor.getValue()).isEqualTo(currentMonth);
+    }
+
+    // ===== 응답 포맷 검증 =====
+
+    @Test
+    @DisplayName("응답 resultCode는 S-200")
+    void getMonthlyPayouts_response_result_code_is_S_200() {
+        Long userId = 1L;
+        when(payoutQueryUseCase.findMonthlyPayouts(eq(userId), anyInt(), anyInt()))
+                .thenReturn(emptyResult());
+
+        RsData<PayoutListResponseDto> response = payoutController.getMonthlyPayouts(userId, 2026, 2);
+
+        assertThat(response.getResultCode()).isEqualTo("S-200");
+    }
+
+    @Test
+    @DisplayName("응답 msg는 정산 목록 조회에 성공했습니다.")
+    void getMonthlyPayouts_response_msg() {
+        Long userId = 1L;
+        when(payoutQueryUseCase.findMonthlyPayouts(eq(userId), anyInt(), anyInt()))
+                .thenReturn(emptyResult());
+
+        RsData<PayoutListResponseDto> response = payoutController.getMonthlyPayouts(userId, 2026, 2);
+
+        assertThat(response.getMsg()).isEqualTo(SuccessCode.PAYOUT_LIST_FOUND.getMsg());
+    }
+
+    @Test
+    @DisplayName("UseCase 반환값이 응답 data에 담김")
+    void getMonthlyPayouts_response_data_equals_useCase_result() {
+        Long userId = 1L;
+        PayoutListResponseDto expected = resultWithAmount(new BigDecimal("500000"));
+        when(payoutQueryUseCase.findMonthlyPayouts(userId, 2026, 2)).thenReturn(expected);
+
+        RsData<PayoutListResponseDto> response = payoutController.getMonthlyPayouts(userId, 2026, 2);
+
+        assertThat(response.getData()).isEqualTo(expected);
+    }
+
+    // ===== 비즈니스 시나리오 =====
+
+    @Test
+    @DisplayName("판매자가 없으면 summary 금액이 모두 0이고 목록이 비어있음")
+    void getMonthlyPayouts_unknown_seller_returns_empty_result() {
+        Long userId = 999L;
+        when(payoutQueryUseCase.findMonthlyPayouts(eq(userId), anyInt(), anyInt()))
+                .thenReturn(emptyResult());
+
+        RsData<PayoutListResponseDto> response = payoutController.getMonthlyPayouts(userId, 2026, 2);
+        PayoutListResponseDto data = response.getData();
+
+        assertThat(data.summary().totalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(data.summary().creditedAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(data.summary().pendingCreditAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(data.payouts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정산 완료 + 지급 완료 항목이 있으면 summary에 반영됨")
+    void getMonthlyPayouts_with_credited_payout_reflects_in_summary() {
+        Long userId = 1L;
+        BigDecimal totalAmount = new BigDecimal("500000");
+        BigDecimal creditedAmount = new BigDecimal("380000");
+        BigDecimal pendingAmount = new BigDecimal("120000");
+
+        PayoutListResponseDto.Summary summary = new PayoutListResponseDto.Summary(
+                totalAmount, creditedAmount, pendingAmount
+        );
+        PayoutResponseDto payoutDto = PayoutResponseDto.builder()
+                .id(1L)
+                .status("CREDITED")
+                .amount(creditedAmount)
+                .payoutDate(LocalDateTime.of(2026, 2, 10, 0, 0))
+                .creditDate(LocalDateTime.of(2026, 2, 25, 0, 0))
+                .build();
+
+        PayoutListResponseDto result = new PayoutListResponseDto(summary, List.of(payoutDto));
+        when(payoutQueryUseCase.findMonthlyPayouts(userId, 2026, 2)).thenReturn(result);
+
+        RsData<PayoutListResponseDto> response = payoutController.getMonthlyPayouts(userId, 2026, 2);
+        PayoutListResponseDto data = response.getData();
+
+        assertThat(data.summary().totalAmount()).isEqualByComparingTo(totalAmount);
+        assertThat(data.summary().creditedAmount()).isEqualByComparingTo(creditedAmount);
+        assertThat(data.summary().pendingCreditAmount()).isEqualByComparingTo(pendingAmount);
+        assertThat(data.payouts()).hasSize(1);
+        assertThat(data.payouts().get(0).getStatus()).isEqualTo("CREDITED");
+    }
+
+    @Test
+    @DisplayName("정산 완료되었지만 지급 미완료 항목은 status가 COMPLETED")
+    void getMonthlyPayouts_completed_but_not_credited_status_is_COMPLETED() {
+        Long userId = 1L;
+        PayoutResponseDto payoutDto = PayoutResponseDto.builder()
+                .id(2L)
+                .status("COMPLETED")
+                .amount(new BigDecimal("200000"))
+                .payoutDate(LocalDateTime.of(2026, 2, 20, 0, 0))
+                .creditDate(null)
+                .build();
+
+        PayoutListResponseDto result = new PayoutListResponseDto(
+                new PayoutListResponseDto.Summary(
+                        new BigDecimal("200000"), BigDecimal.ZERO, new BigDecimal("200000")
+                ),
+                List.of(payoutDto)
+        );
+        when(payoutQueryUseCase.findMonthlyPayouts(userId, 2026, 2)).thenReturn(result);
+
+        RsData<PayoutListResponseDto> response = payoutController.getMonthlyPayouts(userId, 2026, 2);
+        PayoutResponseDto dto = response.getData().payouts().get(0);
+
+        assertThat(dto.getStatus()).isEqualTo("COMPLETED");
+        assertThat(dto.getCreditDate()).isNull();
+    }
+
+    // ===== 헬퍼 메서드 =====
+
+    private PayoutListResponseDto emptyResult() {
+        return new PayoutListResponseDto(
+                new PayoutListResponseDto.Summary(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO),
+                Collections.emptyList()
+        );
+    }
+
+    private PayoutListResponseDto resultWithAmount(BigDecimal totalAmount) {
+        return new PayoutListResponseDto(
+                new PayoutListResponseDto.Summary(totalAmount, BigDecimal.ZERO, totalAmount),
+                Collections.emptyList()
+        );
+    }
+}


### PR DESCRIPTION
## 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #214 

## ✨️ 작업 내용
  1. 판매자 정산 조회 API GET /api/v1/payouts?year=&month=                                                                                                                                                                                         
    - summary (총액/지급완료/대기) + 정산 목록 반환                                                                                                                                                                                                
  2. 컨트롤러 테스트 (8개 케이스)                                                                                                                                                                                                                  
    - 파라미터 전달, 응답 포맷, 비즈니스 시나리오                                                                                                                                                                                                  
  3. 지급 스케줄 변경
    - 매일 23:59 → 매월 15일 + 말일 23:59

## 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

## 📸 구현 결과 (?)
<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
