### PR TITLE
[Feature] #226 : 유저 기부로그 API 구현

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
         - id: payout
           uri: http://127.0.0.1:8084
           predicates:
-            - Path=/api/payout/**
+            - Path=/api/payout/**, /api/v1/donations/**
           filters:
             - name: JwtAuthenticationFilter
 

--- a/payout/src/main/java/com/mossy/boundedContext/donation/app/common/DonationQueryUseCase.java
+++ b/payout/src/main/java/com/mossy/boundedContext/donation/app/common/DonationQueryUseCase.java
@@ -1,13 +1,22 @@
 package com.mossy.boundedContext.donation.app.common;
 
+import com.mossy.boundedContext.donation.domain.DonationLog;
 import com.mossy.boundedContext.donation.in.dto.response.DonationLogResponseDto;
+import com.mossy.boundedContext.donation.in.dto.response.DonationMonthlyHistoryResponseDto;
+import com.mossy.boundedContext.donation.in.dto.response.DonationSummaryResponseDto;
 import com.mossy.boundedContext.donation.out.DonationLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +33,55 @@ public class DonationQueryUseCase {
                 .findByUser_IdAndCreatedAtBetween(userId, from, to)
                 .stream()
                 .map(DonationLogResponseDto::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public DonationSummaryResponseDto getDonationSummary(Long userId) {
+        LocalDate now = LocalDate.now();
+        int year = now.getYear();
+        int month = now.getMonthValue();
+
+        LocalDateTime from = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDateTime to = from.plusMonths(1);
+
+        List<DonationLog> logs = donationLogRepository.findByUser_IdAndCreatedAtBetween(userId, from, to);
+        return DonationSummaryResponseDto.from(year, month, logs);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DonationMonthlyHistoryResponseDto> getMonthlyDonationHistory(Long userId) {
+        List<DonationLog> all = donationLogRepository.findByUser_IdOrderByCreatedAtDesc(userId);
+
+        Map<YearMonth, List<DonationLog>> grouped = all.stream()
+                .collect(Collectors.groupingBy(
+                        log -> YearMonth.from(log.getCreatedAt()),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    YearMonth ym = entry.getKey();
+                    List<DonationLog> monthLogs = entry.getValue();
+                    BigDecimal totalAmount = monthLogs.stream()
+                            .map(DonationLog::getAmount)
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+                    BigDecimal totalCarbonOffset = monthLogs.stream()
+                            .map(DonationLog::getCarbonOffset)
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+                    List<DonationLogResponseDto> dtos = monthLogs.stream()
+                            .map(DonationLogResponseDto::from)
+                            .toList();
+                    return DonationMonthlyHistoryResponseDto.builder()
+                            .year(ym.getYear())
+                            .month(ym.getMonthValue())
+                            .totalAmount(totalAmount)
+                            .totalCarbonOffset(totalCarbonOffset)
+                            .donationCount(monthLogs.size())
+                            .logs(dtos)
+                            .build();
+                })
                 .toList();
     }
 }

--- a/payout/src/main/java/com/mossy/boundedContext/donation/in/DonationController.java
+++ b/payout/src/main/java/com/mossy/boundedContext/donation/in/DonationController.java
@@ -2,6 +2,8 @@ package com.mossy.boundedContext.donation.in;
 
 import com.mossy.boundedContext.donation.app.common.DonationQueryUseCase;
 import com.mossy.boundedContext.donation.in.dto.response.DonationLogResponseDto;
+import com.mossy.boundedContext.donation.in.dto.response.DonationMonthlyHistoryResponseDto;
+import com.mossy.boundedContext.donation.in.dto.response.DonationSummaryResponseDto;
 import com.mossy.exception.SuccessCode;
 import com.mossy.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +25,24 @@ import java.util.List;
 public class DonationController {
 
     private final DonationQueryUseCase donationQueryUseCase;
+
+    @Operation(summary = "이번 달 기부 요약 조회", description = "구매자의 이번 달 기부 총액, 탄소 절감량, 건수를 조회합니다.")
+    @GetMapping("/summary")
+    public RsData<DonationSummaryResponseDto> getDonationSummary(
+            @RequestHeader("X-User-Id") Long userId) {
+
+        DonationSummaryResponseDto summary = donationQueryUseCase.getDonationSummary(userId);
+        return RsData.success(SuccessCode.DONATION_SUMMARY_FOUND, summary);
+    }
+
+    @Operation(summary = "달별 기부 내역 전체 조회", description = "구매자의 전체 기부 내역을 달별로 묶어서 최신순으로 조회합니다.")
+    @GetMapping("/history")
+    public RsData<List<DonationMonthlyHistoryResponseDto>> getMonthlyDonationHistory(
+            @RequestHeader("X-User-Id") Long userId) {
+
+        List<DonationMonthlyHistoryResponseDto> history = donationQueryUseCase.getMonthlyDonationHistory(userId);
+        return RsData.success(SuccessCode.DONATION_HISTORY_FOUND, history);
+    }
 
     @Operation(summary = "월별 기부 내역 조회", description = "해당 월의 기부 내역을 조회합니다. year/month 미입력 시 현재 월로 조회합니다.")
     @GetMapping("/monthly")

--- a/payout/src/main/java/com/mossy/boundedContext/donation/in/dto/response/DonationMonthlyHistoryResponseDto.java
+++ b/payout/src/main/java/com/mossy/boundedContext/donation/in/dto/response/DonationMonthlyHistoryResponseDto.java
@@ -1,0 +1,17 @@
+package com.mossy.boundedContext.donation.in.dto.response;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record DonationMonthlyHistoryResponseDto(
+        int year,
+        int month,
+        BigDecimal totalAmount,
+        BigDecimal totalCarbonOffset,
+        int donationCount,
+        List<DonationLogResponseDto> logs
+) {
+}

--- a/payout/src/main/java/com/mossy/boundedContext/donation/in/dto/response/DonationSummaryResponseDto.java
+++ b/payout/src/main/java/com/mossy/boundedContext/donation/in/dto/response/DonationSummaryResponseDto.java
@@ -1,0 +1,32 @@
+package com.mossy.boundedContext.donation.in.dto.response;
+
+import com.mossy.boundedContext.donation.domain.DonationLog;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record DonationSummaryResponseDto(
+        int year,
+        int month,
+        BigDecimal totalAmount,
+        BigDecimal totalCarbonOffset,
+        int donationCount
+) {
+    public static DonationSummaryResponseDto from(int year, int month, List<DonationLog> logs) {
+        BigDecimal totalAmount = logs.stream()
+                .map(DonationLog::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalCarbonOffset = logs.stream()
+                .map(DonationLog::getCarbonOffset)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return DonationSummaryResponseDto.builder()
+                .year(year)
+                .month(month)
+                .totalAmount(totalAmount)
+                .totalCarbonOffset(totalCarbonOffset)
+                .donationCount(logs.size())
+                .build();
+    }
+}

--- a/payout/src/main/java/com/mossy/boundedContext/donation/out/DonationLogRepository.java
+++ b/payout/src/main/java/com/mossy/boundedContext/donation/out/DonationLogRepository.java
@@ -29,4 +29,6 @@ public interface DonationLogRepository extends JpaRepository<DonationLog, Long> 
     List<DonationLog> findByOrderItemId(Long orderItemId);
 
     List<DonationLog> findByUser_IdAndCreatedAtBetween(Long userId, LocalDateTime from, LocalDateTime to);
+
+    List<DonationLog> findByUser_IdOrderByCreatedAtDesc(Long userId);
 }

--- a/payout/src/main/java/com/mossy/exception/SuccessCode.java
+++ b/payout/src/main/java/com/mossy/exception/SuccessCode.java
@@ -10,6 +10,8 @@ public enum SuccessCode implements BaseCode {
     PAYOUT_DAILY_WALLET_NOTHING_TO_PROCESS(200, "처리할 정산이 없습니다."),
     PAYOUT_DAILY_WALLET_CREDIT_PROCESSED(201, "판매자 지급 처리가 완료되었습니다."),
     DONATION_LOGS_FOUND(200, "기부 내역 조회에 성공했습니다."),
+    DONATION_SUMMARY_FOUND(200, "기부 요약 조회에 성공했습니다."),
+    DONATION_HISTORY_FOUND(200, "기부 월별 내역 조회에 성공했습니다."),
     PAYOUT_LIST_FOUND(200, "정산 목록 조회에 성공했습니다.");
 
     private final int status;


### PR DESCRIPTION
## 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #226 

## ✨️ 작업 내용
<!-- 작업 내용을 간략히 설명해주세요 -->
  Base URL: {서버주소}/api/v1/donations
  공통 헤더: X-User-Id: {구매자 userId} (필수)

  ---
  1. 이번 달 기부 요약 (서머리 화면)
  2. 달별 기부 상세 내역 (상세 화면)

  GET /api/v1/donations/history

  Request
  Header: X-User-Id: 1

## 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

## 📸 구현 결과 (?)
<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
